### PR TITLE
Documentation: Ensure Quickstart is at top of sidebar

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## NEXT
+
+- Changed the order of the documentation in the sidebar to ensure Quickstart is at the top.
+
 ## 0.2.7
 
 - Improved internal logic for how an `cai_causal_graph.graph_components.Edge` is instantiated from a dictionary.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,5 +1,7 @@
 # Quickstart
 
+## Causal Graphs
+
 The causal graph fundamentally consists of _nodes_, i.e. variables, and _edges_, i.e. their relationships. For instance,
 a causal graph containing a directed edge `->` between node `A` and node `B` would imply that variable `A` is a causal
 driver of variable `B`, but not the other way around.

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -9,13 +9,13 @@
     "items": [
         {
             "type": "doc",
-            "id": "docs/introduction",
-            "label": "Introduction"
+            "id": "docs/quickstart",
+            "label": "Quickstart"
         },
         {
             "type": "doc",
-            "id": "docs/quickstart",
-            "label": "Quickstart"
+            "id": "docs/introduction",
+            "label": "Introduction"
         },
         {
             "type": "doc",


### PR DESCRIPTION
## Description and Motivation
<!--- Describe your changes, and the motivation behind them, in detail -->
Feedback from user acceptance testing. Ensure quickstart is at the top.

## Additional Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Jira). -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (moving code around, general refactoring improvements)
- [x] Documentation (documentation)


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have reviewed my own PR? (review the PR as you are reviewing someone else's PR)
- [x] I have implemented all requirements? (see JIRA, project documentation)
- [x] I am affecting someone else's work? If so: I have added those people as reviewers?
- [ ] I have added comments to all the bits that are hard to follow
- [ ] At a bare minimum, I tested this manually
- [ ] I have added unit test(s)
- [ ] Is this a bugfix? If so have I added a regression test?
- [x] Does this PR satisfy the [one PR, one concern](https://medium.com/@fagnerbrack/one-pull-request-one-concern-e84a27dfe9f1) rule?
- [ ] If needed, documentation has been added/updated?
- [x] I have updated the appropriate changelog with a line for my changes
- [ ] If this PR breaks reproducibility, have I added a note in the changelog explaining the break in reproducibility
      and its extent?

## Screenshots (if appropriate):
