### PR TITLE
Bug: Identify Utils when Destination is an Ancestor of Source

### DIFF
--- a/cai_causal_graph/identify_utils.py
+++ b/cai_causal_graph/identify_utils.py
@@ -181,6 +181,10 @@ def identify_instruments(
     # verify inputs and obtain node identifiers
     source_id, destination_id = _verify_identify_inputs(graph, source, destination)
 
+    # return an empty list if the destination is an ancestor of the source
+    if destination_id in graph.get_ancestors(source_id):
+        return []
+
     # get all the confounders between the source and destination
     confounders = identify_confounders(graph, source_id, destination_id)
 
@@ -255,6 +259,10 @@ def identify_mediators(
     """
     # verify inputs and obtain node identifiers
     source_id, destination_id = _verify_identify_inputs(graph, source, destination)
+
+    # return an empty list if the destination is an ancestor of the source
+    if destination_id in graph.get_ancestors(source_id):
+        return []
 
     # get all the confounders between the source and destination
     confounders = identify_confounders(graph, source_id, destination_id)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## NEXT
+
+- Fixed a bug in `cai_causal_graph.identify_utils.identify_instruments` and
+  `cai_causal_graph.identify_utils.identify_mediators`, where an unclear error was raised if the `source` node was a
+  descendant of the `destination` node. Instead, these methods now return an empty list in that case.
+
 ## 0.3.2
 
 - Improved documentation.

--- a/tests/test_identify_utils.py
+++ b/tests/test_identify_utils.py
@@ -346,6 +346,17 @@ class TestIdentifyInstruments(unittest.TestCase):
         with self.assertRaises(ValueError):
             identify_instruments(cg, source=cg.get_node('x'), destination=cg.get_node('x'))
 
+    def test_edge_cases(self):
+        # define an edge case causal graph
+        cg = CausalGraph()
+        cg.add_edge('x', 'y')
+        cg.add_edge('z', 'x')
+        cg.add_edge('z', 'y')
+
+        # call identify_instruments on the effect of y on x
+        instruments = identify_instruments(cg, source='y', destination='x')
+        self.assertEqual(len(instruments), 0)
+
 
 class TestIdentifyMediators(unittest.TestCase):
     def test_simple(self):
@@ -507,3 +518,14 @@ class TestIdentifyMediators(unittest.TestCase):
             identify_mediators(cg, source=cg.get_node('x'), destination='x')
         with self.assertRaises(ValueError):
             identify_mediators(cg, source=cg.get_node('x'), destination=cg.get_node('x'))
+
+    def test_edge_cases(self):
+        # define an edge case causal graph
+        cg = CausalGraph()
+        cg.add_edge('x', 'y')
+        cg.add_edge('z', 'x')
+        cg.add_edge('z', 'y')
+
+        # call identify_mediators on the effect of y on x
+        mediators = identify_mediators(cg, source='y', destination='x')
+        self.assertEqual(len(mediators), 0)


### PR DESCRIPTION
## Description and Motivation
This PR fixes a bug where an unclear error was raised when `destination -> source`. Now, it simply returns an empty list.

## Additional Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Jira). -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (moving code around, general refactoring improvements)
- [ ] Documentation (documentation)


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have reviewed my own PR? (review the PR as you are reviewing someone else's PR)
- [ ] I have implemented all requirements? (see JIRA, project documentation)
- [ ] I am affecting someone else's work? If so: I have added those people as reviewers?
- [ ] I have added comments to all the bits that are hard to follow
- [ ] At a bare minimum, I tested this manually
- [ ] I have added unit test(s)
- [ ] Is this a bugfix? If so have I added a regression test?
- [ ] Does this PR satisfy the [one PR, one concern](https://medium.com/@fagnerbrack/one-pull-request-one-concern-e84a27dfe9f1) rule?
- [ ] If needed, documentation has been added/updated?
- [ ] I have updated the appropriate changelog with a line for my changes
- [ ] If this PR breaks reproducibility, have I added a note in the changelog explaining the break in reproducibility
      and its extent?

## Screenshots (if appropriate):
