### PR TITLE
Feature: Identify Markov boundary and Get Neighbors for Causal Graph and Skeleton

### DIFF
--- a/cai_causal_graph/causal_graph.py
+++ b/cai_causal_graph/causal_graph.py
@@ -1220,7 +1220,12 @@ class CausalGraph(HasIdentifier, HasMetadata, CanDictSerialize, CanDictDeseriali
         return self.skeleton.get_neighbors(identifier)
 
     def get_neighbor_nodes(self, node: NodeLike) -> List[Node]:
-        """Get all neighbor nodes for a specific node."""
+        """
+        Get all neighbor nodes for a specific node.
+
+        Note: It does not matter what the edge type is, as long as there is an edge between `node` and another node,
+        that other node is considered its neighbor.
+        """
         return self.get_nodes(identifier=self.get_neighbors(node))  # type: ignore
 
     def get_children_nodes(self, node: NodeLike) -> List[Node]:

--- a/cai_causal_graph/causal_graph.py
+++ b/cai_causal_graph/causal_graph.py
@@ -100,22 +100,22 @@ class Skeleton(CanDictSerialize, CanDictDeserialize):
         # Instantiate new nodes to remove any edge information.
         return [Node(n.identifier, meta=n.meta) for n in self._graph.nodes]
 
-    def get_node(self, identifier: str) -> Node:
+    def get_node(self, identifier: NodeLike) -> Node:
         """Return node that matches the identifier."""
-        matching_nodes = [node for node in self.nodes if node.identifier == identifier]
-        assert len(matching_nodes) > 0, f'No node found matching identifier {identifier}.'
-        assert (
-            len(matching_nodes) < 2
-        ), f'Found more than one matching node for identifier {identifier}: {matching_nodes}!'
+        node_id = Node.identifier_from(identifier)
+        matching_nodes = [node for node in self.nodes if node.identifier == node_id]
+        assert len(matching_nodes) > 0, f'No node found matching identifier {node_id}.'
+        assert len(matching_nodes) < 2, f'Found more than one matching node for identifier {node_id}: {matching_nodes}!'
         return matching_nodes[0]
 
     def get_node_names(self) -> List[str]:
         """Return a list of each node's identifier."""
         return [node.identifier for node in self._graph.nodes]
 
-    def node_exists(self, identifier: str) -> bool:
+    def node_exists(self, identifier: NodeLike) -> bool:
         """Check if node exists."""
-        return identifier in self.get_node_names()
+        node_id = Node.identifier_from(identifier)
+        return node_id in self.get_node_names()
 
     @property
     def edges(self) -> List[Edge]:
@@ -171,8 +171,19 @@ class Skeleton(CanDictSerialize, CanDictDeserialize):
         validate_pair_type(pair)
         return self.edge_exists(pair[0], pair[1])
 
+    def get_neighbors(self, node: NodeLike) -> List[str]:
+        """Get node identifiers for all neighbor nodes for a specific node."""
+        node_id = Node.identifier_from(node)
+        assert node_id in self.get_node_names(), f'Node with identifier {node_id} does not exist in this skeleton.'
+        return list(self.to_networkx().neighbors(node_id))
+
+    def get_neighbor_nodes(self, node: NodeLike) -> List[Node]:
+        """Get all neighbor nodes for a specific node."""
+        neighbor_ids = self.get_neighbors(node)
+        return [node for node in self.nodes if node.identifier in neighbor_ids]
+
     def is_empty(self) -> bool:
-        """Return True if there are no nodes and edges. False otherwise."""
+        """Return `True` if there are no nodes and edges. `False` otherwise."""
         return len(self.nodes) == 0 and len(self.edges) == 0
 
     @property
@@ -1197,6 +1208,20 @@ class CausalGraph(HasIdentifier, HasMetadata, CanDictSerialize, CanDictDeseriali
     def remove_edge(self, /, source: str, destination: str, *, edge_type: Optional[EdgeType] = None):
         """Remove a specific edge by source and destination node identifiers, as well as edge type."""
         self.delete_edge(source=source, destination=destination, edge_type=edge_type)
+
+    def get_neighbors(self, node: NodeLike) -> List[str]:
+        """
+        Get node identifiers for all neighbor nodes for a specific node.
+
+        Note: It does not matter what the edge type is, as long as there is an edge between `node` and another node,
+        that other node is considered its neighbor.
+        """
+        identifier = self._NodeCls.identifier_from(node)  # As subclasses override NodeCls, need correct identifier.
+        return self.skeleton.get_neighbors(identifier)
+
+    def get_neighbor_nodes(self, node: NodeLike) -> List[Node]:
+        """Get all neighbor nodes for a specific node."""
+        return self.get_nodes(identifier=self.get_neighbors(node))
 
     def get_children_nodes(self, node: NodeLike) -> List[Node]:
         """Get all children nodes for a specific node."""

--- a/cai_causal_graph/causal_graph.py
+++ b/cai_causal_graph/causal_graph.py
@@ -1221,7 +1221,7 @@ class CausalGraph(HasIdentifier, HasMetadata, CanDictSerialize, CanDictDeseriali
 
     def get_neighbor_nodes(self, node: NodeLike) -> List[Node]:
         """Get all neighbor nodes for a specific node."""
-        return self.get_nodes(identifier=self.get_neighbors(node))
+        return self.get_nodes(identifier=self.get_neighbors(node))  # type: ignore
 
     def get_children_nodes(self, node: NodeLike) -> List[Node]:
         """Get all children nodes for a specific node."""

--- a/cai_causal_graph/identify_utils.py
+++ b/cai_causal_graph/identify_utils.py
@@ -371,7 +371,7 @@ def identify_markov_boundary(graph: Union[CausalGraph, Skeleton], node: NodeLike
         mb = list(
             set(graph.get_parents(node_id))
             | child_set
-            | {parent for child in child_set for parent in graph.get_parents(child)}
+            | {parent for child in child_set for parent in graph.get_parents(child) if parent != node_id}
         )
     else:
         # We already know it is Skeleton here so no need for elif.

--- a/cai_causal_graph/identify_utils.py
+++ b/cai_causal_graph/identify_utils.py
@@ -308,7 +308,7 @@ def identify_markov_boundary(graph: Union[CausalGraph, Skeleton], node: NodeLike
     Identify all the Markov boundary for the specified `node in the provided `graph`.
 
     The Markov boundary is defined as the minimal Markov blanket. The Markov blanket is defined as the set of variables
-    such that if you condition on them, it makes your variable of interest (`node`) in this case conditionally
+    such that if you condition on them, it makes your variable of interest (`node` in this case) conditionally
     independent of all other variables. The Markov boundary is minimal meaning that you cannot drop any variables from
     it for the conditional independence condition to still hold.
 
@@ -341,7 +341,8 @@ def identify_markov_boundary(graph: Union[CausalGraph, Skeleton], node: NodeLike
         >>> cg.add_edge('g', 'e')  # 'g' is a parent of 'e', which is a child of 'a'
         >>> cg.add_edge('g', 'z')
         >>>
-        >>> # compute Markov boundary for node; output: ['b', 'c', 'd', 'e', 'f', 'g']
+        >>> # compute Markov boundary for node 'a'; output: ['b', 'c', 'd', 'e', 'f', 'g']
+        >>> # parents: 'b' and 'c', children: 'd' and 'e', and other parents of children are 'f' and 'g'
         >>> # note the order may not match but the elements will be those six.
         >>> markov_boundary: List[str] = identify_markov_boundary(cg, node='a')
 
@@ -350,10 +351,11 @@ def identify_markov_boundary(graph: Union[CausalGraph, Skeleton], node: NodeLike
         >>> from cai_causal_graph import Skeleton
         >>> from cai_causal_graph.identify_utils import identify_markov_boundary
         >>>
-        >>> # Use causal graph from above and get is skeleton
+        >>> # use causal graph from above and get is skeleton
         >>> skeleton: Skeleton = cg.skeleton
         >>>
-        >>> # compute Markov boundary for node; output: ['b', 'c', 'd', 'e']
+        >>> # compute Markov boundary for node 'a'; output: ['b', 'c', 'd', 'e']
+        >>> # as we have no directional information in the undirected skeleton, the neighbors of 'a' are returned.
         >>> # note the order may not match but the elements will be those four.
         >>> markov_boundary: List[str] = identify_markov_boundary(skeleton, node='a')
 

--- a/cai_causal_graph/identify_utils.py
+++ b/cai_causal_graph/identify_utils.py
@@ -350,7 +350,12 @@ def identify_markov_boundary(graph: Union[CausalGraph, Skeleton], node: NodeLike
         >>> from cai_causal_graph import Skeleton
         >>> from cai_causal_graph.identify_utils import identify_markov_boundary
         >>>
-        >>> TODO
+        >>> # Use causal graph from above and get is skeleton
+        >>> skeleton: Skeleton = cg.skeleton
+        >>>
+        >>> # compute Markov boundary for node; output: ['b', 'c', 'd', 'e']
+        >>> # note the order may not match but the elements will be those four.
+        >>> markov_boundary: List[str] = identify_markov_boundary(skeleton, node='a')
 
     :param graph: The graph given by a `cai_causal_graph.causal_graph.CausalGraph` or
         `cai_causal_graph.causal_graph.Skeleton` instance. If a `cai_causal_graph.causal_graph.CausalGraph` is

--- a/cai_causal_graph/identify_utils.py
+++ b/cai_causal_graph/identify_utils.py
@@ -13,36 +13,40 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import List, Tuple
+from typing import List, Optional, Tuple, Union
 
-from cai_causal_graph import CausalGraph
+from cai_causal_graph import CausalGraph, Skeleton
 from cai_causal_graph.exceptions import CausalGraphErrors
 from cai_causal_graph.graph_components import Node
 from cai_causal_graph.type_definitions import NodeLike
 
 
-def _verify_identify_inputs(graph: CausalGraph, node_1: NodeLike, node_2: NodeLike) -> Tuple[str, str]:
+def _verify_identify_inputs(
+    graph: Union[CausalGraph, Skeleton], node_1: NodeLike, node_2: Optional[NodeLike] = None
+) -> Tuple[str, str]:
     """
     Verify the inputs to the identify utilities.
 
-    :param graph: The causal graph given by a `cai_causal_graph.causal_graph.CausalGraph` instance. This must be a DAG,
-        i.e. it must only contain directed edges and be acyclic, otherwise a `TypeError` is raised.
+    :param graph: The graph given by a `cai_causal_graph.causal_graph.CausalGraph` or
+        `cai_causal_graph.causal_graph.Skeleton` instance. If a `cai_causal_graph.causal_graph.CausalGraph` is
+        provided, it must be a DAG, i.e. it must only contain directed edges and be acyclic, otherwise a `TypeError`
+        is raised.
     :param node_1: The first node or its identifier.
-    :param node_2: The second node or its identifier.
-    :return: A tuple of the node identifiers.
+    :param node_2: The second (optional) node or its identifier.
+    :return: A tuple of the node identifiers. If node_2 was `None`, then `''` is returned for its identifier.
     """
-    if not graph.is_dag():
+    if isinstance(graph, CausalGraph) and not graph.is_dag():
         raise TypeError(f'Expected a DAG, but got a mixed causal graph.')
 
     # Confirm node_1 and node_2 are in the graph.
     if not graph.node_exists(node_1):
         raise CausalGraphErrors.NodeDoesNotExistError(f'Node not found: {node_1}')
-    if not graph.node_exists(node_2):
+    if node_2 is not None and not graph.node_exists(node_2):
         raise CausalGraphErrors.NodeDoesNotExistError(f'Node not found: {node_2}')
 
     # Coerce NodeLike to identifier. We already know they are NodeLike as node_exists does this.
     node_1_id = Node.identifier_from(node_1)
-    node_2_id = Node.identifier_from(node_2)
+    node_2_id = Node.identifier_from(node_2) if node_2 is not None else ''
 
     # Ensure node_1 != node_2
     if node_1_id == node_2_id or node_1 == node_2:
@@ -297,3 +301,80 @@ def identify_mediators(
                 break
 
     return list(candidate_nodes)
+
+
+def identify_markov_boundary(graph: Union[CausalGraph, Skeleton], node: NodeLike) -> List[str]:
+    """
+    Identify all the Markov boundary for the specified `node in the provided `graph`.
+
+    The Markov boundary is defined as the minimal Markov blanket. The Markov blanket is defined as the set of variables
+    such that if you condition on them, it makes your variable of interest (`node`) in this case conditionally
+    independent of all other variables. The Markov boundary is minimal meaning that you cannot drop any variables from
+    it for the conditional independence condition to still hold.
+
+    For a directed acyclic graph (DAG), provided as a `cai_causal_graph.causal_graph.CausalGraph` instance, the Markov
+    boundary of node 'A' is defined as the parents of 'A', the children of 'A', and the other parents of the children
+    of 'A'.
+
+    For an undirected graph, provided as a `cai_causal_graph.causal_graph.Skeleton` instance, the Markov boundary of
+    node 'A' is simply defined as the neighbors of 'A'.
+
+    See https://en.wikipedia.org/wiki/Markov_blanket for further information.
+
+    Example for `cai_causal_graph.causal_graph.CausalGraph`:
+        >>> from typing import List
+        >>> from cai_causal_graph import CausalGraph
+        >>> from cai_causal_graph.identify_utils import identify_markov_boundary
+        >>>
+        >>> # define a causal graph
+        >>> cg = CausalGraph()
+        >>> cg.add_edge('u', 'b')
+        >>> cg.add_edge('v', 'c')
+        >>> cg.add_edge('b', 'a')  # 'b' is a parent of 'a'
+        >>> cg.add_edge('c', 'a')  # 'c' is a parent of 'a'
+        >>> cg.add_edge('a', 'd')  # 'd' is a child of 'a'
+        >>> cg.add_edge('a', 'e')  # 'e' is a child of 'a'
+        >>> cg.add_edge('w', 'f')
+        >>> cg.add_edge('f', 'd')  # 'f' is a parent of 'd', which is a child of 'a'
+        >>> cg.add_edge('d', 'x')
+        >>> cg.add_edge('d', 'y')
+        >>> cg.add_edge('g', 'e')  # 'g' is a parent of 'e', which is a child of 'a'
+        >>> cg.add_edge('g', 'z')
+        >>>
+        >>> # compute Markov boundary for node; output: ['b', 'c', 'd', 'e', 'f', 'g']
+        >>> # note the order may not match but the elements will be those six.
+        >>> markov_boundary: List[str] = identify_markov_boundary(cg, node='a')
+
+    Example for `cai_causal_graph.causal_graph.Skeleton`:
+        >>> from typing import List
+        >>> from cai_causal_graph import Skeleton
+        >>> from cai_causal_graph.identify_utils import identify_markov_boundary
+        >>>
+        >>> TODO
+
+    :param graph: The graph given by a `cai_causal_graph.causal_graph.CausalGraph` or
+        `cai_causal_graph.causal_graph.Skeleton` instance. If a `cai_causal_graph.causal_graph.CausalGraph` is
+        provided, it must be a DAG, i.e. it must only contain directed edges and be acyclic, otherwise a `TypeError`
+        is raised.
+    :param node: The node or its identifier.
+    :return: A list of all node identifiers for the nodes in the Markov boundary of `node`.
+    """
+
+    # verify inputs and obtain node identifier
+    if isinstance(graph, (CausalGraph, Skeleton)):
+        node_id, _ = _verify_identify_inputs(graph, node, None)
+    else:
+        raise TypeError(f'Expected graph to be passed as a CausalGraph or Skeleton object. Got {type(graph)}.')
+
+    if isinstance(graph, CausalGraph):
+        child_set = set(graph.get_children(node_id))
+        mb = list(
+            set(graph.get_parents(node_id))
+            | child_set
+            | {parent for child in child_set for parent in graph.get_parents(child)}
+        )
+    else:
+        # We already know it is Skeleton here so no need for elif.
+        mb = graph.get_neighbors(node_id)
+
+    return mb

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## NEXT
+
+- TODO: Added identify_markov_boundary ...
+- TODO: Added get_neighbors ...
+
 ## 0.3.4
 
 - Extended documentation to provide further information regarding the types of mixed graphs that can be defined in a

--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,14 @@
 
 ## NEXT
 
-- TODO: Added identify_markov_boundary ...
-- TODO: Added get_neighbors ...
+- Added the `cai_causal_graph.identify_utils.identify_markov_boundary` utility function, which allows you to identify
+  the Markov boundary of a node in a `cai_causal_graph.causal_graph.CausalGraph` or in a
+  `cai_causal_graph.causal_graph.Skeleton`.
+- Added `get_neighbor_nodes` and `get_neighbors` methods to `cai_causal_graph.causal_graph.CausalGraph` and
+  `cai_causal_graph.causal_graph.Skeleton`. `get_neighbor_nodes` returns the nodes neighboring the specified node while
+  `get_neighbors` returns the identifiers of the neighboring nodes. Note: For a
+  `cai_causal_graph.causal_graph.CausalGraph`, it does not matter what the edge type is, as long as there is an edge
+  between the specified node and another node, that other node is considered its neighbor.
 
 ## 0.3.4
 

--- a/docs/causal_graph_utils.md
+++ b/docs/causal_graph_utils.md
@@ -87,3 +87,7 @@ cg.add_edge('x', 'y')
 # find the mediators between 'x' and 'y'; output: ['m']
 mediator_variables: List[str] = identify_mediators(cg, source='x', destination='y')
 ```
+
+### Identifying Markov Boundary
+
+TODO

--- a/docs/causal_graph_utils.md
+++ b/docs/causal_graph_utils.md
@@ -90,4 +90,54 @@ mediator_variables: List[str] = identify_mediators(cg, source='x', destination='
 
 ### Identifying Markov Boundary
 
-TODO
+The `cai-causal-graph` package implements the `cai_causal_graph.identify_utils.identify_markov_boundary` utility 
+function, which allows you to identify the Markov boundary for a variable in a directed acyclic graph (DAG) or a 
+variable in an undirected graph.
+
+The Markov boundary is defined as the minimal Markov blanket. The Markov blanket is defined as the set of variables
+such that if you condition on them, it makes your variable of interest (`node` in this case) conditionally independent 
+of all other variables. The Markov boundary is minimal meaning that you cannot drop any variables from it for the 
+conditional independence condition to still hold.
+
+For a DAG, provided as a `cai_causal_graph.causal_graph.CausalGraph` instance, the Markov boundary of a node is defined 
+as its parents, its children, and the other parents of its children.
+
+For an undirected graph, provided as a `cai_causal_graph.causal_graph.Skeleton` instance, the Markov boundary of a 
+node is simply defined as its neighbors.
+
+See https://en.wikipedia.org/wiki/Markov_blanket for further information. The code example below uses the graph 
+from this site.
+
+```python
+from typing import List
+from cai_causal_graph import CausalGraph, Skeleton
+from cai_causal_graph.identify_utils import identify_markov_boundary
+
+# define a causal graph
+cg = CausalGraph()
+cg.add_edge('u', 'b')
+cg.add_edge('v', 'c')
+cg.add_edge('b', 'a')  # 'b' is a parent of 'a'
+cg.add_edge('c', 'a')  # 'c' is a parent of 'a'
+cg.add_edge('a', 'd')  # 'd' is a child of 'a'
+cg.add_edge('a', 'e')  # 'e' is a child of 'a'
+cg.add_edge('w', 'f')
+cg.add_edge('f', 'd')  # 'f' is a parent of 'd', which is a child of 'a'
+cg.add_edge('d', 'x')
+cg.add_edge('d', 'y')
+cg.add_edge('g', 'e')  # 'g' is a parent of 'e', which is a child of 'a'
+cg.add_edge('g', 'z')
+
+# compute Markov boundary for node 'a'; output: ['b', 'c', 'd', 'e', 'f', 'g']
+# parents: 'b' and 'c', children: 'd' and 'e', and other parents of children are 'f' and 'g'
+# note the order may not match but the elements will be those six.
+markov_boundary: List[str] = identify_markov_boundary(cg, node='a')
+
+# use causal graph from above and get is skeleton
+skeleton: Skeleton = cg.skeleton
+
+# compute Markov boundary for node 'a'; output: ['b', 'c', 'd', 'e']
+# as we have no directional information in the undirected skeleton, the neighbors of 'a' are returned.
+# note the order may not match but the elements will be those four.
+markov_boundary: List[str] = identify_markov_boundary(skeleton, node='a')
+```

--- a/docs/causal_graph_utils.md
+++ b/docs/causal_graph_utils.md
@@ -91,7 +91,7 @@ mediator_variables: List[str] = identify_mediators(cg, source='x', destination='
 ### Identifying Markov Boundary
 
 The `cai-causal-graph` package implements the `cai_causal_graph.identify_utils.identify_markov_boundary` utility 
-function, which allows you to identify the Markov boundary for a variable in a directed acyclic graph (DAG) or a 
+function, which allows you to identify the Markov boundary for a variable in a directed acyclic graph (DAG) or for a 
 variable in an undirected graph.
 
 The Markov boundary is defined as the minimal Markov blanket. The Markov blanket is defined as the set of variables

--- a/tests/test_causal_graph.py
+++ b/tests/test_causal_graph.py
@@ -24,6 +24,7 @@ import pandas
 from cai_causal_graph import CausalGraph, EdgeType, NodeVariableType
 from cai_causal_graph import __version__ as VERSION
 from cai_causal_graph.exceptions import CausalGraphErrors
+from cai_causal_graph.graph_components import Node
 
 
 class TestCausalGraphSerialization(unittest.TestCase):
@@ -712,6 +713,25 @@ class TestCausalGraphSerialization(unittest.TestCase):
             causal_graph_deepcopy.get_node('x').get_identifier(),
             self.fully_connected_graph.get_node('x').get_identifier(),
         )
+
+    def test_neighbors(self):
+        neighbors = self.fully_connected_graph.get_neighbors('x')
+        self.assertEqual(len(neighbors), 2)
+        self.assertSetEqual(set(neighbors), {'z1', 'z2'})
+
+        neighbors = self.fully_connected_graph.get_neighbors(self.fully_connected_graph.get_node('x'))
+        self.assertEqual(len(neighbors), 2)
+        self.assertSetEqual(set(neighbors), {'z1', 'z2'})
+
+        neighbor_nodes = self.fully_connected_graph.get_neighbor_nodes('x')
+        self.assertEqual(len(neighbor_nodes), 2)
+        self.assertTrue(all(isinstance(n, Node) for n in neighbor_nodes))
+        self.assertSetEqual({n.identifier for n in neighbor_nodes}, {'z1', 'z2'})
+
+        neighbor_nodes = self.fully_connected_graph.get_neighbor_nodes(self.fully_connected_graph.get_node('x'))
+        self.assertEqual(len(neighbor_nodes), 2)
+        self.assertTrue(all(isinstance(n, Node) for n in neighbor_nodes))
+        self.assertSetEqual({n.identifier for n in neighbor_nodes}, {'z1', 'z2'})
 
     def test_get_children_graph(self):
         cg_original = CausalGraph()

--- a/tests/test_identify_utils.py
+++ b/tests/test_identify_utils.py
@@ -18,7 +18,12 @@ from itertools import combinations
 
 from cai_causal_graph import CausalGraph, TimeSeriesCausalGraph
 from cai_causal_graph.exceptions import CausalGraphErrors
-from cai_causal_graph.identify_utils import identify_confounders, identify_instruments, identify_mediators, identify_markov_boundary
+from cai_causal_graph.identify_utils import (
+    identify_confounders,
+    identify_instruments,
+    identify_markov_boundary,
+    identify_mediators,
+)
 from cai_causal_graph.type_definitions import EDGE_T
 
 

--- a/tests/test_identify_utils.py
+++ b/tests/test_identify_utils.py
@@ -18,7 +18,7 @@ from itertools import combinations
 
 from cai_causal_graph import CausalGraph, TimeSeriesCausalGraph
 from cai_causal_graph.exceptions import CausalGraphErrors
-from cai_causal_graph.identify_utils import identify_confounders, identify_instruments, identify_mediators
+from cai_causal_graph.identify_utils import identify_confounders, identify_instruments, identify_mediators, identify_markov_boundary
 from cai_causal_graph.type_definitions import EDGE_T
 
 
@@ -62,32 +62,39 @@ class TestIdentifyConfounders(unittest.TestCase):
     def test_graph_1(self):
         # compute confounders between source and destination
         confounders = identify_confounders(self.graph_1, node_1='x', node_2='y')
+        self.assertEqual(len(confounders), 1)
         self.assertSetEqual(set(confounders), {'z'})
         # Confirm you can also pass Nodes
         confounders = identify_confounders(
             self.graph_1, node_1=self.graph_1.get_node('x'), node_2=self.graph_1.get_node('y')
         )
+        self.assertEqual(len(confounders), 1)
         self.assertSetEqual(set(confounders), {'z'})
 
     def test_graph_2(self):
         # compute confounders between source and destination
         confounders = identify_confounders(self.graph_2, node_1='x', node_2='y')
+        self.assertEqual(len(confounders), 1)
         self.assertSetEqual(set(confounders), {'u'})
         # Confirm you can pass mix of Node and identifier
         confounders = identify_confounders(self.graph_2, node_1='x', node_2=self.graph_2.get_node('y'))
+        self.assertEqual(len(confounders), 1)
         self.assertSetEqual(set(confounders), {'u'})
 
     def test_graph_3(self):
         # compute confounders between source and destination
         confounders = identify_confounders(self.graph_3, node_1='x', node_2='y')
+        self.assertEqual(len(confounders), 1)
         self.assertSetEqual(set(confounders), {'u'})
         # Confirm you can pass mix of Node and identifier
         confounders = identify_confounders(self.graph_3, node_1=self.graph_3.get_node('x'), node_2='y')
+        self.assertEqual(len(confounders), 1)
         self.assertSetEqual(set(confounders), {'u'})
 
     def test_graph_4(self):
         # compute confounders between source and destination
         confounders = identify_confounders(self.graph_4, node_1='x', node_2='y')
+        self.assertEqual(len(confounders), 2)
         self.assertSetEqual(set(confounders), {'u', 'z'})
 
     def test_non_dag(self):
@@ -133,10 +140,13 @@ class TestIdentifyConfounders(unittest.TestCase):
                 confounders_1b = identify_confounders(cg, node_1=v, node_2=u)
                 confounders_2a = identify_confounders(cg_rev, node_1=u, node_2=v)
                 confounders_2b = identify_confounders(cg_rev, node_1=v, node_2=u)
+                self.assertEqual(len(confounders_1a), len(confounders_1b))
                 self.assertSetEqual(set(confounders_1a), set(confounders_1b))
+                self.assertEqual(len(confounders_2a), len(confounders_2b))
                 self.assertSetEqual(set(confounders_2a), set(confounders_2b))
                 if (u == 'x' and v == 'y') or (u == 'y' and v == 'x'):
                     # If x, y then the answers should match for the graphs with swapped x - y edge
+                    self.assertEqual(len(confounders_1a), len(confounders_2a))
                     self.assertSetEqual(set(confounders_1a), set(confounders_2a))
 
     def test_bigger_graph(self):
@@ -169,8 +179,10 @@ class TestIdentifyConfounders(unittest.TestCase):
             cg.add_edge(f'yc{i - 1}', f'yc{i}')
 
         confounders = identify_confounders(cg, 'x', 'y')
+        self.assertEqual(len(confounders), 1)
         self.assertSetEqual(set(confounders), {'u'})
         confounders = identify_confounders(cg, 'y', 'x')
+        self.assertEqual(len(confounders), 1)
         self.assertSetEqual(set(confounders), {'u'})
 
     def test_time_series_graph(self):
@@ -185,6 +197,7 @@ class TestIdentifyConfounders(unittest.TestCase):
 
         # compute confounders between source and destination
         confounders = identify_confounders(ts_cg, node_1='x', node_2='y')
+        self.assertEqual(len(confounders), 1)
         self.assertSetEqual(set(confounders), {'z'})
 
 
@@ -199,6 +212,7 @@ class TestIdentifyInstruments(unittest.TestCase):
 
         # identify instrumental variables
         instruments = identify_instruments(cg, source='x', destination='y')
+        self.assertEqual(len(instruments), 1)
         self.assertSetEqual(set(instruments), {'z'})
 
     def test_multiple_instruments(self):
@@ -213,6 +227,7 @@ class TestIdentifyInstruments(unittest.TestCase):
 
         # identify instrumental variables
         instruments = identify_instruments(cg, source='x', destination='y')
+        self.assertEqual(len(instruments), 3)
         self.assertSetEqual(set(instruments), {'z_3', 'z_2', 'z_1'})
 
     def test_diamond_and_multiple_confounders(self):
@@ -230,6 +245,7 @@ class TestIdentifyInstruments(unittest.TestCase):
 
         # identify instrumental variables
         instruments = identify_instruments(cg, source='x', destination='y')
+        self.assertEqual(len(instruments), 3)
         self.assertSetEqual(set(instruments), {'z_1', 'z_2', 'z_3'})
 
     def test_no_instruments(self):
@@ -306,6 +322,7 @@ class TestIdentifyInstruments(unittest.TestCase):
 
         # identify instrumental variables
         instruments = identify_instruments(ts_cg, source='x', destination='y')
+        self.assertEqual(len(instruments), 3)
         self.assertSetEqual(set(instruments), {'z', 'z lag(n=1)', 'x lag(n=1)'})
 
     def test_nodelike(self):
@@ -318,6 +335,7 @@ class TestIdentifyInstruments(unittest.TestCase):
 
         # identify instrumental variables
         instruments = identify_instruments(cg, source=cg.get_node('x'), destination=cg.get_node('y'))
+        self.assertEqual(len(instruments), 1)
         self.assertSetEqual(set(instruments), {'z'})
 
     def test_error_cases(self):
@@ -370,6 +388,7 @@ class TestIdentifyMediators(unittest.TestCase):
 
         # identify mediators
         mediators = identify_mediators(cg, source='x', destination='y')
+        self.assertEqual(len(mediators), 1)
         self.assertSetEqual(set(mediators), {'m'})
 
     def test_multiple_mediators(self):
@@ -384,6 +403,7 @@ class TestIdentifyMediators(unittest.TestCase):
 
         # identify mediators
         mediators = identify_mediators(cg, source='x', destination='y')
+        self.assertEqual(len(mediators), 2)
         self.assertSetEqual(set(mediators), {'m1', 'm2'})
 
     def test_multiple_mediators_diamond(self):
@@ -403,6 +423,7 @@ class TestIdentifyMediators(unittest.TestCase):
 
         # identify mediators
         mediators = identify_mediators(cg, source='x', destination='y')
+        self.assertEqual(len(mediators), 2)
         self.assertSetEqual(set(mediators), {'m1', 'm4'})
 
     def test_chain(self):
@@ -413,6 +434,7 @@ class TestIdentifyMediators(unittest.TestCase):
 
         # identify mediators
         mediators = identify_mediators(cg, source='x', destination='y')
+        self.assertEqual(len(mediators), 1)
         self.assertSetEqual(set(mediators), {'m'})
 
     def test_no_mediators(self):
@@ -477,6 +499,7 @@ class TestIdentifyMediators(unittest.TestCase):
 
         # identify mediators
         mediators = identify_mediators(ts_cg, source='x', destination='y')
+        self.assertEqual(len(mediators), 1)
         self.assertSetEqual(set(mediators), {'m'})
 
     def test_nodelike(self):
@@ -490,6 +513,7 @@ class TestIdentifyMediators(unittest.TestCase):
 
         # identify mediators
         mediators = identify_mediators(cg, source=cg.get_node('x'), destination=cg.get_node('y'))
+        self.assertEqual(len(mediators), 1)
         self.assertSetEqual(set(mediators), {'m'})
 
     def test_error_cases(self):
@@ -529,3 +553,123 @@ class TestIdentifyMediators(unittest.TestCase):
         # call identify_mediators on the effect of y on x
         mediators = identify_mediators(cg, source='y', destination='x')
         self.assertEqual(len(mediators), 0)
+
+
+class TestIdentifyMarkovBoundary(unittest.TestCase):
+    def test_simple_cg(self):
+        cg = CausalGraph()
+        cg.add_edge('u', 'b')
+        cg.add_edge('v', 'c')
+        cg.add_edge('b', 'a')  # 'b' is a parent of 'a'
+        cg.add_edge('c', 'a')  # 'c' is a parent of 'a'
+        cg.add_edge('a', 'd')  # 'd' is a child of 'a'
+        cg.add_edge('a', 'e')  # 'e' is a child of 'a'
+        cg.add_edge('w', 'f')
+        cg.add_edge('f', 'd')  # 'f' is a parent of 'd', which is a child of 'a'
+        cg.add_edge('d', 'x')
+        cg.add_edge('d', 'y')
+        cg.add_edge('g', 'e')  # 'g' is a parent of 'e', which is a child of 'a'
+        cg.add_edge('g', 'z')
+
+        markov_boundary = identify_markov_boundary(cg, node='a')
+        self.assertEqual(len(markov_boundary), 6)
+        self.assertSetEqual(set(markov_boundary), {'b', 'c', 'd', 'e', 'f', 'g'})
+
+    def test_simple_skeleton(self):
+        # TODO
+        pass
+
+    def test_non_dag(self):
+        # Create a mixed graph
+        cg = CausalGraph()
+        cg.add_edge('x', 'm', edge_type=EDGE_T.UNDIRECTED_EDGE)
+        cg.add_edge('m', 'y')
+        cg.add_edge('u', 'x')
+        cg.add_edge('u', 'y')
+
+        with self.assertRaises(TypeError):
+            identify_markov_boundary(cg, node='x')
+
+        # Confirm it works for its skeleton though.
+        mb = identify_markov_boundary(cg.skeleton, node='x')
+        self.assertEqual(len(mb), 2)
+        self.assertSetEqual(set(mb), {'m', 'u'})
+
+        mb = identify_markov_boundary(cg.skeleton, node='m')
+        self.assertEqual(len(mb), 2)
+        self.assertSetEqual(set(mb), {'x', 'y'})
+
+        mb = identify_markov_boundary(cg.skeleton, node='y')
+        self.assertEqual(len(mb), 2)
+        self.assertSetEqual(set(mb), {'m', 'u'})
+
+        mb = identify_markov_boundary(cg.skeleton, node='u')
+        self.assertEqual(len(mb), 2)
+        self.assertSetEqual(set(mb), {'x', 'y'})
+
+    # def test_time_series_graph(self):
+    #     # create a time-series causal graph
+    #     ts_cg = TimeSeriesCausalGraph()
+    #     ts_cg.add_edge('x', 'm')
+    #     ts_cg.add_edge('m', 'y')
+    #     ts_cg.add_edge('u', 'x')
+    #     ts_cg.add_edge('u', 'y')
+    #     ts_cg.add_edge('m lag(n=1)', 'm')
+    #     ts_cg.add_edge('u lag(n=1)', 'u')
+    #     ts_cg.add_edge('x lag(n=1)', 'x')
+    #     ts_cg.add_edge('y lag(n=1)', 'y')
+    #
+    #     # identify mediators
+    #     mediators = identify_mediators(ts_cg, source='x', destination='y')
+    #     self.assertSetEqual(set(mediators), {'m'})
+    #
+    # def test_nodelike(self):
+    #     # define a simple graph (standard mediator example)
+    #     cg = CausalGraph()
+    #     cg.add_edge('x', 'm')
+    #     cg.add_edge('m', 'y')
+    #     cg.add_edge('u', 'x')
+    #     cg.add_edge('u', 'y')
+    #     cg.add_edge('x', 'y')
+    #
+    #     # identify mediators
+    #     mediators = identify_mediators(cg, source=cg.get_node('x'), destination=cg.get_node('y'))
+    #     self.assertSetEqual(set(mediators), {'m'})
+    #
+    # def test_error_cases(self):
+    #     # define a simple graph (standard mediator example)
+    #     cg = CausalGraph()
+    #     cg.add_edge('x', 'm')
+    #     cg.add_edge('m', 'y')
+    #     cg.add_edge('u', 'x')
+    #     cg.add_edge('u', 'y')
+    #     cg.add_edge('x', 'y')
+    #
+    #     # node_1 not in graph
+    #     with self.assertRaises(CausalGraphErrors.NodeDoesNotExistError):
+    #         identify_mediators(cg, source='w', destination='y')
+    #
+    #     # node_2 not in graph
+    #     with self.assertRaises(CausalGraphErrors.NodeDoesNotExistError):
+    #         identify_mediators(cg, source='x', destination='w')
+    #
+    #     # node_1 == node_2
+    #     with self.assertRaises(ValueError):
+    #         identify_mediators(cg, source='x', destination='x')
+    #     with self.assertRaises(ValueError):
+    #         identify_mediators(cg, source='x', destination=cg.get_node('x'))
+    #     with self.assertRaises(ValueError):
+    #         identify_mediators(cg, source=cg.get_node('x'), destination='x')
+    #     with self.assertRaises(ValueError):
+    #         identify_mediators(cg, source=cg.get_node('x'), destination=cg.get_node('x'))
+    #
+    # def test_edge_cases(self):
+    #     # define an edge case causal graph
+    #     cg = CausalGraph()
+    #     cg.add_edge('x', 'y')
+    #     cg.add_edge('z', 'x')
+    #     cg.add_edge('z', 'y')
+    #
+    #     # call identify_mediators on the effect of y on x
+    #     mediators = identify_mediators(cg, source='y', destination='x')
+    #     self.assertEqual(len(mediators), 0)

--- a/tests/test_skeleton.py
+++ b/tests/test_skeleton.py
@@ -18,8 +18,9 @@ import unittest
 import networkx
 import numpy
 
-from cai_causal_graph.causal_graph import CausalGraph, Skeleton
+from cai_causal_graph import CausalGraph, Skeleton
 from cai_causal_graph.exceptions import CausalGraphErrors
+from cai_causal_graph.graph_components import Node
 
 
 class TestCausalGraphSkeletonSerialization(unittest.TestCase):
@@ -139,6 +140,27 @@ class TestCausalGraphSkeletonSerialization(unittest.TestCase):
         # Test that deleting edges works fine
         self.fully_connected_graph.delete_edge('x', 'z1')
         self.assertEqual(3, len(self.fully_connected_graph.skeleton.edges))
+
+    def test_neighbors(self):
+        neighbors = self.fully_connected_graph.skeleton.get_neighbors('x')
+        self.assertEqual(len(neighbors), 2)
+        self.assertSetEqual(set(neighbors), {'z1', 'z2'})
+
+        neighbors = self.fully_connected_graph.skeleton.get_neighbors(self.fully_connected_graph.skeleton.get_node('x'))
+        self.assertEqual(len(neighbors), 2)
+        self.assertSetEqual(set(neighbors), {'z1', 'z2'})
+
+        neighbor_nodes = self.fully_connected_graph.skeleton.get_neighbor_nodes('x')
+        self.assertEqual(len(neighbor_nodes), 2)
+        self.assertTrue(all(isinstance(n, Node) for n in neighbor_nodes))
+        self.assertSetEqual({n.identifier for n in neighbor_nodes}, {'z1', 'z2'})
+
+        neighbor_nodes = self.fully_connected_graph.skeleton.get_neighbor_nodes(
+            self.fully_connected_graph.skeleton.get_node('x')
+        )
+        self.assertEqual(len(neighbor_nodes), 2)
+        self.assertTrue(all(isinstance(n, Node) for n in neighbor_nodes))
+        self.assertSetEqual({n.identifier for n in neighbor_nodes}, {'z1', 'z2'})
 
     def test_adjacency(self):
         adj_1 = numpy.array([[0, 1, 0], [0, 0, 1], [0, 0, 0]])


### PR DESCRIPTION
## Description and Motivation
<!--- Describe your changes, and the motivation behind them, in detail -->
Per a request from @mmiklitz, this PR adds the ability to identify the Markov boundary of a node in a DAG or in an undirected skeleton. To support this `get_neighbors` and `get_neighbor_nodes` were also added to `CausalGraph` and `Skeleton`. 

## Additional Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Jira). -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (moving code around, general refactoring improvements)
- [ ] Documentation (documentation)


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have reviewed my own PR? (review the PR as you are reviewing someone else's PR)
- [x] I have implemented all requirements? (see JIRA, project documentation)
- [x] I am affecting someone else's work? If so: I have added those people as reviewers?
- [ ] I have added comments to all the bits that are hard to follow
- [ ] At a bare minimum, I tested this manually
- [x] I have added unit test(s)
- [ ] Is this a bugfix? If so have I added a regression test?
- [x] Does this PR satisfy the [one PR, one concern](https://medium.com/@fagnerbrack/one-pull-request-one-concern-e84a27dfe9f1) rule?
- [x] If needed, documentation has been added/updated?
- [x] I have updated the appropriate changelog with a line for my changes
- [ ] If this PR breaks reproducibility, have I added a note in the changelog explaining the break in reproducibility
      and its extent?

## Screenshots (if appropriate):
