### PR TITLE
Fix: Skeleton missing __iter__

### DIFF
--- a/cai_causal_graph/causal_graph.py
+++ b/cai_causal_graph/causal_graph.py
@@ -93,6 +93,11 @@ class Skeleton(CanDictSerialize, CanDictDeserialize):
     def __ne__(self, other: object) -> bool:
         """Check if the skeleton is not equal to another skeleton."""
         return not (self == other)
+    
+    def __iter__(self) -> Iterator:
+        """Return item,value tuples of the content of self.to_dict()."""
+        for k, v in self.to_dict().items():
+            yield k, v
 
     @property
     def nodes(self) -> List[Node]:

--- a/cai_causal_graph/causal_graph.py
+++ b/cai_causal_graph/causal_graph.py
@@ -93,7 +93,7 @@ class Skeleton(CanDictSerialize, CanDictDeserialize):
     def __ne__(self, other: object) -> bool:
         """Check if the skeleton is not equal to another skeleton."""
         return not (self == other)
-    
+
     def __iter__(self) -> Iterator:
         """Return item,value tuples of the content of self.to_dict()."""
         for k, v in self.to_dict().items():

--- a/cai_causal_graph/causal_graph.py
+++ b/cai_causal_graph/causal_graph.py
@@ -95,7 +95,7 @@ class Skeleton(CanDictSerialize, CanDictDeserialize):
         return not (self == other)
 
     def __iter__(self) -> Iterator:
-        """Return item,value tuples of the content of self.to_dict()."""
+        """Return item,value tuples of the content of `self.to_dict()`."""
         for k, v in self.to_dict().items():
             yield k, v
 
@@ -426,7 +426,7 @@ class CausalGraph(HasIdentifier, HasMetadata, CanDictSerialize, CanDictDeseriali
             return self.get_edge(item[0], item[1])
 
     def __iter__(self) -> Iterator:
-        """Return item,value tuples of the content of self.to_dict()."""
+        """Return item,value tuples of the content of `self.to_dict()`."""
         for k, v in self.to_dict().items():
             yield k, v
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## NEXT
+
+- Added `__iter__` to `cai_causal_graph.causal_graph.Skeleton`
+
 ## 0.3.5
 
 - Added the `cai_causal_graph.identify_utils.identify_markov_boundary` utility function, which allows you to identify

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## NEXT
 
-- Added `__iter__` to `cai_causal_graph.causal_graph.Skeleton`
+- Added `__iter__` to `cai_causal_graph.causal_graph.Skeleton`.
 
 ## 0.3.5
 


### PR DESCRIPTION
## Description and Motivation
<!--- Describe your changes, and the motivation behind them, in detail -->
When adding support for Skeleton on Dara, the graph was not json serialised correctly by fastapi. The reason being that `__iter__` was missing from the class.

## Additional Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Jira). -->
Needed for Dara to support `Skeleton` graphs on `CausalGraphViewer` component.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested that this fixed the issue I was having on Dara by manually applying this changes within the env

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (moving code around, general refactoring improvements)
- [ ] Documentation (documentation)


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have reviewed my own PR? (review the PR as you are reviewing someone else's PR)
- [x] I have implemented all requirements? (see JIRA, project documentation)
- [ ] I am affecting someone else's work? If so: I have added those people as reviewers?
- [ ] I have added comments to all the bits that are hard to follow
- [x] At a bare minimum, I tested this manually
- [ ] I have added unit test(s)
- [ ] Is this a bugfix? If so have I added a regression test?
- [x] Does this PR satisfy the [one PR, one concern](https://medium.com/@fagnerbrack/one-pull-request-one-concern-e84a27dfe9f1) rule?
- [ ] If needed, documentation has been added/updated?
- [x] I have updated the appropriate changelog with a line for my changes
- [ ] If this PR breaks reproducibility, have I added a note in the changelog explaining the break in reproducibility
      and its extent?

## Screenshots (if appropriate):
