### PR TITLE
Bugfix: Re-added fix for extend

### DIFF
--- a/cai_causal_graph/__init__.py
+++ b/cai_causal_graph/__init__.py
@@ -31,7 +31,7 @@ __all__ = [
     'VARIABLE_NAME',
 ]
 
-__version__ = '0.3.10'
+__version__ = '0.3.11.dev0'
 
 from cai_causal_graph.causal_graph import CausalGraph, Skeleton
 from cai_causal_graph.time_series_causal_graph import TimeSeriesCausalGraph

--- a/cai_causal_graph/time_series_causal_graph.py
+++ b/cai_causal_graph/time_series_causal_graph.py
@@ -441,7 +441,7 @@ class TimeSeriesCausalGraph(CausalGraph):
             assert maxlag is not None
 
             # create all the nodes from 1 to backward_steps
-            for lag in range(1, backward_steps + 1):
+            for lag in range(0, backward_steps + 1):
                 for node in minimal_graph.get_nodes():
                     # create the node with -lag (if it does not exist)
                     lagged_node = self._get_lagged_node(node=node, lag=-lag)
@@ -490,7 +490,7 @@ class TimeSeriesCausalGraph(CausalGraph):
             # With the forward extension, the maximum positive lag is forward_steps.
 
             # first create all the nodes from 1 to forward_steps
-            for lag in range(1, forward_steps + 1):
+            for lag in range(0, forward_steps + 1):
                 for node in minimal_graph.get_nodes():
                     # create the node with +lag (if it does not exist)
                     lagged_node = self._get_lagged_node(node=node, lag=lag)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## NEXT
+
+- Fixed a bug in the `cai_causal_graph.time_series_causal_graph.TimeSeriesCausalGraph.extend_graph` method in
+  `cai_causal_graph.time_series_causal_graph.TimeSeriesCausalGraph` where the method was not adding nodes correctly with
+  particular graph configurations.
+
 ## 0.3.10
 
 - Fixed a bug in the `cai_causal_graph.time_series_causal_graph.TimeSeriesCausalGraph.get_minimal_graph` method in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ cache_dir = '/dev/null'
 
 [tool.poetry]
 name = "cai-causal-graph"
-version = "0.3.10"
+version = "0.3.11.dev0"
 description = "A Causal AI package for causal graphs."
 license = "Apache-2.0"
 authors = ["causaLens <opensource@causalens.com>"]

--- a/tests/test_time_series_graph.py
+++ b/tests/test_time_series_graph.py
@@ -805,6 +805,16 @@ class TestTimeSeriesCausalGraph(unittest.TestCase):
             name = get_name_with_lag('a', i)
             self.assertTrue(ext_graph.node_exists(name))
 
+        # test with a graph that is not aligned at lag 0
+        graph = TimeSeriesCausalGraph()
+        graph.add_nodes_from(['tier_0_0 lag(n=1)', 'tier_0_1', 'tier_1', 'tier_2'])
+        graph.add_edge('tier_0_0 lag(n=1)', 'tier_0_1')
+        graph.add_edge('tier_0_1', 'tier_2')
+        graph.add_edge('tier_1', 'tier_2')
+
+        extended_graph = graph.extend_graph(backward_steps=1, forward_steps=0)
+        self.assertTrue(extended_graph.node_exists('tier_0_0'))
+
     def test_extend_graph_forward(self):
         # with 1 steps
         # dag


### PR DESCRIPTION
## Description and Motivation
Re-adding a bugfix I had removed.

## Additional Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Jira). -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (moving code around, general refactoring improvements)
- [ ] Documentation (documentation)


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have reviewed my own PR? (review the PR as you are reviewing someone else's PR)
- [ ] I have implemented all requirements? (see JIRA, project documentation)
- [ ] I am affecting someone else's work? If so: I have added those people as reviewers?
- [ ] I have added comments to all the bits that are hard to follow
- [ ] At a bare minimum, I tested this manually
- [ ] I have added unit test(s)
- [ ] Is this a bugfix? If so have I added a regression test?
- [ ] Does this PR satisfy the [one PR, one concern](https://medium.com/@fagnerbrack/one-pull-request-one-concern-e84a27dfe9f1) rule?
- [ ] If needed, documentation has been added/updated?
- [ ] I have updated the appropriate changelog with a line for my changes
- [ ] If this PR breaks reproducibility, have I added a note in the changelog explaining the break in reproducibility
      and its extent?

## Screenshots (if appropriate):
