### PR TITLE
Improvement: Faster topological sort for Time Series Causal Graph

### DIFF
--- a/cai_causal_graph/causal_graph.py
+++ b/cai_causal_graph/causal_graph.py
@@ -1591,11 +1591,11 @@ class CausalGraph(HasIdentifier, HasMetadata, CanDictSerialize, CanDictDeseriali
 
     def get_topological_order(self, return_all: bool = False) -> Union[List[str], List[List[str]]]:
         """
-        Get either a single or all topological orders of the graph.
+        Return either a single or all topological orders of the graph.
 
-        A topological order is a non-unique permutation of the nodes such that an edge from `A` to `B` implies that `A`
-        appears before `B` in the topological sort order. Generating all possible topological orders may be expensive
-        for large graphs.
+        A topological order is a non-unique permutation of the nodes such that an edge from `'A'` to `'B'` implies
+        that `'A'` appears before `'B'` in the topological sort order. Generating all possible topological orders may
+        be expensive for large graphs.
 
         It is only possible to get topological order if the graph is a valid DAG.
 

--- a/cai_causal_graph/time_series_causal_graph.py
+++ b/cai_causal_graph/time_series_causal_graph.py
@@ -329,7 +329,7 @@ class TimeSeriesCausalGraph(CausalGraph):
 
                 return ordered_nodes
             else:
-                # check it is a dag
+                # check it is a dag. Not needed in the other cases as it is already checked in the super method
                 assert self.is_dag(), 'The graph is not a DAG. The topological order is not valid.'
                 return list(
                     networkx.lexicographical_topological_sort(

--- a/cai_causal_graph/time_series_causal_graph.py
+++ b/cai_causal_graph/time_series_causal_graph.py
@@ -306,6 +306,10 @@ class TimeSeriesCausalGraph(CausalGraph):
         """
         Return the topological order of the graph that is ordered in time.
 
+        :param return_all: If `True`, return all the possible topological orders. Default is `False`.
+        :param respect_time_ordering: If `True`, return the topological order that is ordered in time. Default is
+            `True`.
+
         For more details, see `cai_causal_graph.causal_graph.CausalGraph.get_topological_order`.
         """
         if respect_time_ordering:

--- a/cai_causal_graph/time_series_causal_graph.py
+++ b/cai_causal_graph/time_series_causal_graph.py
@@ -295,40 +295,46 @@ class TimeSeriesCausalGraph(CausalGraph):
                 continue
             assert isinstance(node, str)  # for linting
             # check if the time delta is correct
-            if self.get_node(ordered_nodes[j - 1]).time_lag > self.get_node(ordered_nodes[j]).time_lag:   # type: ignore
+            if self.get_node(ordered_nodes[j - 1]).time_lag > self.get_node(ordered_nodes[j]).time_lag:  # type: ignore
                 return []
 
         return ordered_nodes
 
-    def get_topological_order(self, return_all: bool = False) -> Union[List[str], List[List[str]]]:
+    def get_topological_order(
+        self, return_all: bool = False, respect_time_ordering: bool = True
+    ) -> Union[List[str], List[List[str]]]:
         """
         Return the topological order of the graph that is ordered in time.
 
         For more details, see `cai_causal_graph.causal_graph.CausalGraph.get_topological_order`.
         """
-        if return_all:
-            ordered_nodes_list = super().get_topological_order(return_all=return_all)
-            # ordered_nodes_list must be a list of lists of strings
-            assert isinstance(ordered_nodes_list, list)
-            assert all(isinstance(x, list) for x in ordered_nodes_list)
+        if respect_time_ordering:
+            if return_all:
+                ordered_nodes_list = super().get_topological_order(return_all=return_all)
+                # ordered_nodes_list must be a list of lists of strings
+                assert isinstance(ordered_nodes_list, list)
+                assert all(isinstance(x, list) for x in ordered_nodes_list)
 
-            ordered_nodes: List[List[str]] = []
+                ordered_nodes: List[List[str]] = []
 
-            for i in range(len(ordered_nodes_list)):
-                assert isinstance(ordered_nodes_list[i], list)
-                tmp = self._get_time_topological_order(ordered_nodes_list[i])   # type: ignore
-                if len(tmp) > 0:
-                    ordered_nodes.append(tmp)
+                for i in range(len(ordered_nodes_list)):
+                    assert isinstance(ordered_nodes_list[i], list)
+                    tmp = self._get_time_topological_order(ordered_nodes_list[i])  # type: ignore
+                    if len(tmp) > 0:
+                        ordered_nodes.append(tmp)
 
-            return ordered_nodes
-        else:
-            # check it is a dag
-            assert self.is_dag(), 'The graph is not a DAG. The topological order is not valid.'
-            return list(
-                networkx.lexicographical_topological_sort(
-                    self.to_networkx(), key=lambda x: self.get_node(x).time_lag  # type: ignore
+                return ordered_nodes
+            else:
+                # check it is a dag
+                assert self.is_dag(), 'The graph is not a DAG. The topological order is not valid.'
+                return list(
+                    networkx.lexicographical_topological_sort(
+                        self.to_networkx(), key=lambda x: self.get_node(x).time_lag  # type: ignore
+                    )
                 )
-            )
+
+        else:
+            return super().get_topological_order(return_all=return_all)
 
     def is_minimal_graph(self) -> bool:
         """

--- a/cai_causal_graph/time_series_causal_graph.py
+++ b/cai_causal_graph/time_series_causal_graph.py
@@ -335,7 +335,7 @@ class TimeSeriesCausalGraph(CausalGraph):
                 for i in range(len(ordered_nodes_list)):
                     assert isinstance(ordered_nodes_list[i], list)
                     tmp = self._get_time_topological_order(ordered_nodes_list[i])  # type: ignore
-                    if tmp not in ordered_nodes and len(tmp) > 0:
+                    if len(tmp) > 0:
                         ordered_nodes.append(tmp)
 
                 return ordered_nodes

--- a/cai_causal_graph/time_series_causal_graph.py
+++ b/cai_causal_graph/time_series_causal_graph.py
@@ -304,13 +304,24 @@ class TimeSeriesCausalGraph(CausalGraph):
         self, return_all: bool = False, respect_time_ordering: bool = True
     ) -> Union[List[str], List[List[str]]]:
         """
-        Return the topological order of the graph that is ordered in time.
+        Return either a single or all topological orders of the graph.
+
+        A topological order is a non-unique permutation of the nodes such that an edge from `'A'` to `'B'` implies
+        that `'A'` appears before `'B'` in the topological sort order. Generating all possible topological orders may
+        be expensive for large graphs.
+
+        It is only possible to get topological order if the graph is a valid DAG.
+
+        For more details, see `cai_causal_graph.causal_graph.CausalGraph.get_topological_order`.
 
         :param return_all: If `True`, return all the possible topological orders. Default is `False`.
         :param respect_time_ordering: If `True`, return the topological order that is ordered in time. Default is
-            `True`.
-
-        For more details, see `cai_causal_graph.causal_graph.CausalGraph.get_topological_order`.
+            `True`. For example, if the graph is `'Y lag(n=1)' -> 'Y' <- 'X'`, then `['X', 'Y lag(n=1)', 'Y']` and
+            `['Y lag(n=1)', 'X', 'Y']` are both valid topological orders. However, only the second one would respect time
+            ordering. If both `return_all` and `respect_time_ordering` are `True`, then only all topological orders
+            that respect time are returned, not all valid topological orders.
+        :return: either a list of strings identifying a single topological order, or a list of lists identifying all
+            possible topological orders.
         """
         if respect_time_ordering:
             if return_all:

--- a/cai_causal_graph/time_series_causal_graph.py
+++ b/cai_causal_graph/time_series_causal_graph.py
@@ -324,7 +324,7 @@ class TimeSeriesCausalGraph(CausalGraph):
                 for i in range(len(ordered_nodes_list)):
                     assert isinstance(ordered_nodes_list[i], list)
                     tmp = self._get_time_topological_order(ordered_nodes_list[i])  # type: ignore
-                    if len(tmp) > 0:
+                    if tmp not in ordered_nodes and len(tmp) > 0:
                         ordered_nodes.append(tmp)
 
                 return ordered_nodes

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## NEXT
+
+- Improved the `cai_causal_graph.time_series_causal_graph.TimeSeriesCausalGraph.get_topological_order` method in
+  `cai_causal_graph.time_series_causal_graph.TimeSeriesCausalGraph` to improve performance. Added a new keyword
+  argument `respect_time_ordering` to allow the user to specify whether the topological order should respect the
+  time ordering of the nodes. If `respect_time_ordering=True`, the topological order will respect the time ordering,
+  otherwise it will not. The default is `respect_time_ordering=True`, matching previous behavior.
+
 ## 0.3.12
 
 - Improved efficiency of `cai_causal_graph.identify_utils.identify_confounders` by performing all operations

--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,7 @@
   otherwise it may not. For example, if the graph is `'Y lag(n=1)' -> 'Y' <- 'X'`, then `['X', 'Y lag(n=1)', 'Y']` and
   `['Y lag(n=1)', 'X', 'Y']` are both valid topological orders. However, only the second one would respect time
   ordering. If both `return_all` and `respect_time_ordering` are `True`, then only all topological orders
-  that respect time are returned, not all valid topological orders. The default is `respect_time_ordering=True`, 
+  that respect time are returned, not all valid topological orders. The default is `respect_time_ordering=True`,
   matching previous behavior.
 
 ## 0.3.12

--- a/changelog.md
+++ b/changelog.md
@@ -4,9 +4,13 @@
 
 - Improved the `cai_causal_graph.time_series_causal_graph.TimeSeriesCausalGraph.get_topological_order` method in
   `cai_causal_graph.time_series_causal_graph.TimeSeriesCausalGraph` to improve performance. Added a new keyword
-  argument `respect_time_ordering` to allow the user to specify whether the topological order should respect the
+  argument `respect_time_ordering` to allow the user to specify whether the topological order must respect the
   time ordering of the nodes. If `respect_time_ordering=True`, the topological order will respect the time ordering,
-  otherwise it will not. The default is `respect_time_ordering=True`, matching previous behavior.
+  otherwise it may not. For example, if the graph is `'Y lag(n=1)' -> 'Y' <- 'X'`, then `['X', 'Y lag(n=1)', 'Y']` and
+  `['Y lag(n=1)', 'X', 'Y']` are both valid topological orders. However, only the second one would respect time
+  ordering. If both `return_all` and `respect_time_ordering` are `True`, then only all topological orders
+  that respect time are returned, not all valid topological orders. The default is `respect_time_ordering=True`, 
+  matching previous behavior.
 
 ## 0.3.12
 

--- a/tests/test_time_series_graph.py
+++ b/tests/test_time_series_graph.py
@@ -1160,6 +1160,11 @@ class TestTimeSeriesCausalGraph(unittest.TestCase):
         self.assertEqual(len(order), 1)
         self.assertListEqual(order[0], ['y lag(n=1)', 'x', 'y'])
 
+        order = tscg.get_topological_order(return_all=True, respect_time_ordering=False)
+        self.assertEqual(len(order), 2)
+        self.assertListEqual(order[0], ['y lag(n=1)', 'x', 'y'])
+        self.assertListEqual(order[1], ['x', 'y lag(n=1)', 'y'])
+
     def test_order_swapped(self):
         tscg = TimeSeriesCausalGraph()
         tscg.add_edge('x', 'y lag(n=1)', edge_type=EdgeType.UNDIRECTED_EDGE)

--- a/tests/test_time_series_graph.py
+++ b/tests/test_time_series_graph.py
@@ -1047,7 +1047,7 @@ class TestTimeSeriesCausalGraph(unittest.TestCase):
         g.add_time_edge('t', -1, 't', 0)
 
         top_order = g.get_topological_order()
-        self.assertListEqual(top_order, ['x lag(n=1)', 't lag(n=1)', 'x', 't', 'y'])
+        self.assertListEqual(top_order, ['t lag(n=1)', 'x lag(n=1)', 'x', 't', 'y'])
 
         top_order = g.get_topological_order(return_all=True)
         self.assertListEqual(
@@ -1092,13 +1092,13 @@ class TestTimeSeriesCausalGraph(unittest.TestCase):
         cg.add_node('y')
         ts_cg = TimeSeriesCausalGraph.from_causal_graph(cg)
 
-        self.assertListEqual(ts_cg.get_topological_order(), ['y', 'x'])
+        self.assertListEqual(ts_cg.get_topological_order(), ['x', 'y'])
         self.assertListEqual(ts_cg.get_topological_order(return_all=True), [['y', 'x'], ['x', 'y']])
 
         extended_graph = ts_cg.extend_graph(1, 1)
         self.assertListEqual(
             extended_graph.get_topological_order(),
-            ['y lag(n=1)', 'x lag(n=1)', 'x', 'y', 'x future(n=1)', 'y future(n=1)'],
+            ['x lag(n=1)', 'y lag(n=1)', 'x', 'y', 'x future(n=1)', 'y future(n=1)'],
         )
 
         # Test with no contemporaneous nodes.

--- a/tests/test_time_series_graph.py
+++ b/tests/test_time_series_graph.py
@@ -1049,6 +1049,10 @@ class TestTimeSeriesCausalGraph(unittest.TestCase):
         top_order = g.get_topological_order()
         self.assertListEqual(top_order, ['t lag(n=1)', 'x lag(n=1)', 'x', 't', 'y'])
 
+        # test with respect time ordering to false
+        top_order = g.get_topological_order(respect_time_ordering=False)
+        self.assertListEqual(top_order, ['t lag(n=1)', 'x', 'x lag(n=1)', 't', 'y'])
+
         top_order = g.get_topological_order(return_all=True)
         self.assertListEqual(
             top_order, [['x lag(n=1)', 't lag(n=1)', 'x', 't', 'y'], ['t lag(n=1)', 'x lag(n=1)', 'x', 't', 'y']]

--- a/tests/test_time_series_graph.py
+++ b/tests/test_time_series_graph.py
@@ -1150,6 +1150,16 @@ class TestTimeSeriesCausalGraph(unittest.TestCase):
             ['z lag(n=2)', 'x lag(n=2)', 'y lag(n=2)', 'z lag(n=1)', 'x lag(n=1)', 'y lag(n=1)', 'z', 'x', 'y'], order
         )
 
+        tscg = TimeSeriesCausalGraph()
+        # y-1 -> y <- x
+        tscg.add_edge('x', 'y')
+        tscg.add_time_edge('y', -1, 'y', 0)
+
+        order = tscg.get_topological_order(return_all=True)
+        # check there's no duplicates
+        self.assertEqual(len(order), 1)
+        self.assertListEqual(order[0], ['y lag(n=1)', 'x', 'y'])
+
     def test_order_swapped(self):
         tscg = TimeSeriesCausalGraph()
         tscg.add_edge('x', 'y lag(n=1)', edge_type=EdgeType.UNDIRECTED_EDGE)


### PR DESCRIPTION
## Description and Motivation
Improved the topological sort for Time Series Causal Graph to avoid to compute all the topological sorts if only one is needed.

To do it, we'll use  https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.dag.lexicographical_topological_sort.html.

We also added a new boolean keyword argument `respect_time_ordering` that defaults at true. If False, then the `CausalGraph`'s topological sort will be used.

## Additional Context
This issue was raise by Max. The solution was discussed with Andrew offline on Slack.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (moving code around, general refactoring improvements)
- [ ] Documentation (documentation)


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have reviewed my own PR? (review the PR as you are reviewing someone else's PR)
- [ ] I have implemented all requirements? (see JIRA, project documentation)
- [ ] I am affecting someone else's work? If so: I have added those people as reviewers?
- [ ] I have added comments to all the bits that are hard to follow
- [ ] At a bare minimum, I tested this manually
- [ ] I have added unit test(s)
- [ ] Is this a bugfix? If so have I added a regression test?
- [ ] Does this PR satisfy the [one PR, one concern](https://medium.com/@fagnerbrack/one-pull-request-one-concern-e84a27dfe9f1) rule?
- [ ] If needed, documentation has been added/updated?
- [ ] I have updated the appropriate changelog with a line for my changes
- [ ] If this PR breaks reproducibility, have I added a note in the changelog explaining the break in reproducibility
      and its extent?

## Screenshots (if appropriate):
