### PR TITLE
Bug: causal graph getitem validation

### DIFF
--- a/cai_causal_graph/causal_graph.py
+++ b/cai_causal_graph/causal_graph.py
@@ -424,6 +424,11 @@ class CausalGraph(HasIdentifier, HasMetadata, CanDictSerialize, CanDictDeseriali
         if not isinstance(item, tuple):
             return self.get_node(item)
         else:
+            if len(item) != 2:
+                raise TypeError(
+                    f'The provided item must either be `NodeLike` (i.e. to return a single node) or a tuple of two '
+                    f'`NodeLike` objects (i.e. to return an edge), got {item}.'
+                )
             return self.get_edge(item[0], item[1])
 
     def __iter__(self) -> Iterator:

--- a/changelog.md
+++ b/changelog.md
@@ -16,7 +16,7 @@
   in `cai_causal_graph.time_series_causal_graph.TimeSeriesCausalGraph` can now be specified in subclasses of
   `cai_causal_graph.time_series_causal_graph.TimeSeriesCausalGraph` using the `_SummaryGraphCls` attribute.
 - Fixed a bug where `__getitem__` method of `cai_causal_graph.causal_graph.CausalGraph` would work when specifying invalid
-  node or edge query, for example a whole path. Instead, now, a `TypeError` is now raised.
+  node or edge query, for example a whole path. Instead, a `TypeError` is now raised.
 
 ## 0.3.14
 

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,8 @@
 - The returned graph type from the `cai_causal_graph.time_series_causal_graph.TimeSeriesCausalGraph.get_summary_graph` method
   in `cai_causal_graph.time_series_causal_graph.TimeSeriesCausalGraph` can now be specified in subclasses of
   `cai_causal_graph.time_series_causal_graph.TimeSeriesCausalGraph` using the `_SummaryGraphCls` attribute.
+- Fixed a bug where `__getitem__` method of `cai_causal_graph.causal_graph.CausalGraph` would work when specifying invalid
+  node or edge query, for example a whole path. Instead, now, a `TypeError` is now raised.
 
 ## 0.3.14
 

--- a/tests/test_causal_graph.py
+++ b/tests/test_causal_graph.py
@@ -24,7 +24,7 @@ import pandas
 from cai_causal_graph import CausalGraph, EdgeType, NodeVariableType
 from cai_causal_graph import __version__ as VERSION
 from cai_causal_graph.exceptions import CausalGraphErrors
-from cai_causal_graph.graph_components import Node
+from cai_causal_graph.graph_components import Edge, Node
 
 
 class TestCausalGraphSerialization(unittest.TestCase):
@@ -129,6 +129,30 @@ class TestCausalGraphSerialization(unittest.TestCase):
         # Also confirm that equality method works.
         self.assertEqual(graph, reconstruction)
         self.assertTrue(graph.__eq__(reconstruction, True))
+
+    def test_get_item(self):
+        causal_graph = CausalGraph()
+        x = Node('x')
+        y = Node('y')
+        causal_graph.add_edge(x, y)
+
+        # test getting node
+        node = causal_graph['x']
+        self.assertIsInstance(node, Node)
+        self.assertEqual(node, causal_graph.get_node('x'))
+
+        # test getting edge
+        edge = causal_graph['x', 'y']
+        self.assertIsInstance(edge, Edge)
+        self.assertEqual(edge, causal_graph.get_edge('x', 'y'))
+
+        # test getting edge which does not exist
+        with self.assertRaises(CausalGraphErrors.EdgeDoesNotExistError):
+            causal_graph['y', 'x']
+
+        # test inappropriate edges
+        with self.assertRaises(TypeError):
+            causal_graph['y', 'x', 'z']
 
     def test_graph_serializes(self):
         """This test ensures different serialization types and JSON serialization as well."""


### PR DESCRIPTION
## Description and Motivation
<!--- Describe your changes, and the motivation behind them, in detail -->
- Fixed a bug where `__getitem__` method of `cai_causal_graph.causal_graph.CausalGraph` would work when specifying invalid
  node or edge query, for example a whole path. Instead, now, a `TypeError` is now raised.
## Additional Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Jira). -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (moving code around, general refactoring improvements)
- [ ] Documentation (documentation)


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have reviewed my own PR? (review the PR as you are reviewing someone else's PR)
- [ ] I have implemented all requirements? (see JIRA, project documentation)
- [ ] I am affecting someone else's work? If so: I have added those people as reviewers?
- [ ] I have added comments to all the bits that are hard to follow
- [ ] At a bare minimum, I tested this manually
- [ ] I have added unit test(s)
- [ ] Is this a bugfix? If so have I added a regression test?
- [ ] Does this PR satisfy the [one PR, one concern](https://medium.com/@fagnerbrack/one-pull-request-one-concern-e84a27dfe9f1) rule?
- [ ] If needed, documentation has been added/updated?
- [ ] I have updated the appropriate changelog with a line for my changes
- [ ] If this PR breaks reproducibility, have I added a note in the changelog explaining the break in reproducibility
      and its extent?

## Screenshots (if appropriate):
