### PR TITLE
Bug: CausalGraph.remove_edge and delete_edge support for `NodeLike`

### DIFF
--- a/cai_causal_graph/causal_graph.py
+++ b/cai_causal_graph/causal_graph.py
@@ -1211,6 +1211,7 @@ class CausalGraph(HasIdentifier, HasMetadata, CanDictSerialize, CanDictDeseriali
         :param destination: Identifier of the node at which the edge terminates.
         :param edge_type: The edge type of the edge to be deleted. Default is None, in which case the type is ignored.
         """
+        source, destination = Node.identifier_from(source), Node.identifier_from(destination)
         assert isinstance(source, str), 'Source identifier must be a string'
         assert isinstance(destination, str), 'Destination identifier must be a string'
 
@@ -1242,7 +1243,7 @@ class CausalGraph(HasIdentifier, HasMetadata, CanDictSerialize, CanDictDeseriali
         self._clean_empty_edge_dictionaries()
         edge.invalidate()
 
-    def remove_edge(self, /, source: str, destination: str, *, edge_type: Optional[EdgeType] = None):
+    def remove_edge(self, /, source: NodeLike, destination: NodeLike, *, edge_type: Optional[EdgeType] = None):
         """Remove a specific edge by source and destination node identifiers, as well as edge type."""
         self.delete_edge(source=source, destination=destination, edge_type=edge_type)
 

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,9 @@
   `cai_causal_graph.time_series_causal_graph.TimeSeriesCausalGraph` using the `_SummaryGraphCls` attribute.
 - Fixed a bug where `__getitem__` method of `cai_causal_graph.causal_graph.CausalGraph` would work when specifying invalid
   node or edge query, for example a whole path. Instead, a `TypeError` is now raised.
+- Fixed a bug where `cai_causal_graph.causal_graph.CausalGraph.delete_edge` would not support passing source and destination
+  as `cai_causal_graph.graph_components.Node`.
+- Added support for passing source and destination as `cai_causal_graph.graph_components.Node` to `cai_causal_graph.causal_graph.CausalGraph.remove_edge`.
 
 ## 0.3.14
 

--- a/tests/test_causal_graph.py
+++ b/tests/test_causal_graph.py
@@ -328,6 +328,15 @@ class TestCausalGraphSerialization(unittest.TestCase):
         with self.assertRaises(CausalGraphErrors.EdgeDoesNotExistError):
             self.fully_connected_graph.delete_edge('x', 'z1')
 
+    def test_delete_edge_by_node(self):
+        # Test that deleting edges works fine
+        self.fully_connected_graph.delete_edge(self.fully_connected_graph['x'], self.fully_connected_graph['z1'])
+        self.assertEqual(3, len(self.fully_connected_graph.get_edges()))
+
+        # check that the appropriate error is raised when deleting the same edge again
+        with self.assertRaises(CausalGraphErrors.EdgeDoesNotExistError):
+            self.fully_connected_graph.delete_edge(self.fully_connected_graph['x'], self.fully_connected_graph['z1'])
+
     def test_replace_node_raises_error(self):
         causal_graph = CausalGraph()
         causal_graph.add_edge('x1', 'x2')

--- a/tests/test_causal_graph_edge_types.py
+++ b/tests/test_causal_graph_edge_types.py
@@ -200,6 +200,20 @@ class TestCausalGraphEdgeTypes(unittest.TestCase):
         self.assertEqual(len(self.dag.get_nodes()), 8)
         self.assertEqual(len(self.dag.get_edges()), 8)
 
+    def test_add_and_remove_edges_with_nodes(self):
+        # add edge and check that it is correctly added
+        self.dag.add_nodes_from(['x', 'y'])
+
+        self.dag.add_edge(self.dag['x'], self.dag['a'], edge_type=EdgeType.DIRECTED_EDGE)
+        self.dag.add_edge(self.dag['x'], self.dag['y'], edge_type=EdgeType.DIRECTED_EDGE)
+        self.assertEqual(len(self.dag.get_nodes()), 8)
+        self.assertEqual(len(self.dag.get_edges()), 9)
+
+        # remove edge
+        self.dag.remove_edge(self.dag['x'], self.dag['y'], edge_type=EdgeType.DIRECTED_EDGE)
+        self.assertEqual(len(self.dag.get_nodes()), 8)
+        self.assertEqual(len(self.dag.get_edges()), 8)
+
     def test_get_parent_graph(self):
         # get a parent graph for the DAG
         pa_dag = self.dag.get_parents_graph('d')


### PR DESCRIPTION
## Description and Motivation
<!--- Describe your changes, and the motivation behind them, in detail -->
- Fixed a bug where `cai_causal_graph.causal_graph.CausalGraph.delete_edge` would not support passing source and destination
  as `cai_causal_graph.graph_components.Node`.
- Added support for passing source and destination as `cai_causal_graph.graph_components.Node` to `cai_causal_graph.causal_graph.CausalGraph.remove_edge`.

## Additional Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Jira). -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (moving code around, general refactoring improvements)
- [ ] Documentation (documentation)


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have reviewed my own PR? (review the PR as you are reviewing someone else's PR)
- [ ] I have implemented all requirements? (see JIRA, project documentation)
- [ ] I am affecting someone else's work? If so: I have added those people as reviewers?
- [ ] I have added comments to all the bits that are hard to follow
- [ ] At a bare minimum, I tested this manually
- [ ] I have added unit test(s)
- [ ] Is this a bugfix? If so have I added a regression test?
- [ ] Does this PR satisfy the [one PR, one concern](https://medium.com/@fagnerbrack/one-pull-request-one-concern-e84a27dfe9f1) rule?
- [ ] If needed, documentation has been added/updated?
- [ ] I have updated the appropriate changelog with a line for my changes
- [ ] If this PR breaks reproducibility, have I added a note in the changelog explaining the break in reproducibility
      and its extent?

## Screenshots (if appropriate):
