### PR TITLE
Bug: Correct TimeSeriesCausalGraph backward extension logic

### DIFF
--- a/cai_causal_graph/time_series_causal_graph.py
+++ b/cai_causal_graph/time_series_causal_graph.py
@@ -202,7 +202,15 @@ class TimeSeriesCausalGraph(CausalGraph):
         neg_lag, pos_lag = lags[0], lags[-1]
 
         # now extend the minimal graph to the current max and min lag to match the current graph
-        self._stationary_graph = minimal_graph.extend_graph(-neg_lag, pos_lag)
+        extended_graph = minimal_graph.extend_graph(-neg_lag, pos_lag)
+
+        # extend_graph can add nodes/edges lagged further than the current furthest lag, delete if they were added
+        for node in extended_graph.nodes:
+            if node.time_lag < neg_lag:
+                extended_graph.delete_node(node)
+
+        self._stationary_graph = extended_graph
+
         return self._stationary_graph
 
     def get_minimal_graph(self) -> TimeSeriesCausalGraph:

--- a/cai_causal_graph/time_series_causal_graph.py
+++ b/cai_causal_graph/time_series_causal_graph.py
@@ -504,10 +504,6 @@ class TimeSeriesCausalGraph(CausalGraph):
 
                     lagged_destination_node = self._get_lagged_node(node=edge.destination, lag=-lag)
 
-                    # check if the new source node would go beyond the backward_steps
-                    if -lag - time_delta < -backward_steps:
-                        continue
-
                     lagged_source_node = self._get_lagged_node(node=edge.source, lag=-lag - time_delta)
 
                     # add the lagged edge

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## NEXT
+
+- Changed the behavior of `cai_causal_graph.time_series_causal_graph.TimeSeriesCausalGraph.extend_graph` when
+  specifying a `backward_steps`. Now, nodes and edges will be added as far back that all nodes at `backward_steps` in
+  the past can be inferred. That is, all nodes up to `backward_steps` will now have all their inbound edges and their
+  parent nodes added. This means that the extended graph may now have nodes at lags further back than `backward_steps`.
+
 ## 0.4.5
 
 - Fixed a bug in `cai_causal_graph.time_series_causal_graph.TimeSeriesCausalGraph.from_adjacency_matrices` for

--- a/tests/test_time_series_graph.py
+++ b/tests/test_time_series_graph.py
@@ -777,7 +777,12 @@ class TestTimeSeriesCausalGraph(unittest.TestCase):
         extended_graph.add_edge('X2 lag(n=1)', 'X2', edge_type=EdgeType.DIRECTED_EDGE)
         extended_graph.add_edge('X3 lag(n=1)', 'X3', edge_type=EdgeType.DIRECTED_EDGE)
         extended_graph.add_edge('X1 lag(n=1)', 'X2', edge_type=EdgeType.DIRECTED_EDGE)
+
         extended_graph.add_edge('X1 lag(n=1)', 'X3 lag(n=1)', edge_type=EdgeType.DIRECTED_EDGE)
+        extended_graph.add_edge('X1 lag(n=2)', 'X1 lag(n=1)', edge_type=EdgeType.DIRECTED_EDGE)
+        extended_graph.add_edge('X2 lag(n=2)', 'X2 lag(n=1)', edge_type=EdgeType.DIRECTED_EDGE)
+        extended_graph.add_edge('X3 lag(n=2)', 'X3 lag(n=1)', edge_type=EdgeType.DIRECTED_EDGE)
+        extended_graph.add_edge('X1 lag(n=2)', 'X2 lag(n=1)', edge_type=EdgeType.DIRECTED_EDGE)
 
         self.assertEqual(extended_dag, extended_graph)
 
@@ -795,6 +800,12 @@ class TestTimeSeriesCausalGraph(unittest.TestCase):
         extended_graph_1.add_edge('X3 lag(n=2)', 'X2', edge_type=EdgeType.DIRECTED_EDGE)
         extended_graph_1.add_edge('X3 lag(n=1)', 'X1 lag(n=1)', edge_type=EdgeType.DIRECTED_EDGE)
 
+        extended_graph_1.add_edge('X1 lag(n=2)', 'X1 lag(n=1)', edge_type=EdgeType.DIRECTED_EDGE)
+        extended_graph_1.add_edge('X2 lag(n=2)', 'X2 lag(n=1)', edge_type=EdgeType.DIRECTED_EDGE)
+        extended_graph_1.add_edge('X3 lag(n=2)', 'X3 lag(n=1)', edge_type=EdgeType.DIRECTED_EDGE)
+        extended_graph_1.add_edge('X3 lag(n=2)', 'X1 lag(n=1)', edge_type=EdgeType.DIRECTED_EDGE)
+        extended_graph_1.add_edge('X3 lag(n=3)', 'X2 lag(n=1)', edge_type=EdgeType.DIRECTED_EDGE)
+
         self.assertEqual(extended_dag_1, extended_graph_1)
 
         # with 2 steps
@@ -802,11 +813,11 @@ class TestTimeSeriesCausalGraph(unittest.TestCase):
         extended_dag = self.tsdag.extend_graph(backward_steps=2)
 
         # create the extended graph from the previous extended graph
-        extended_graph.add_edge('X1 lag(n=2)', 'X1 lag(n=1)', edge_type=EdgeType.DIRECTED_EDGE)
-        extended_graph.add_edge('X2 lag(n=2)', 'X2 lag(n=1)', edge_type=EdgeType.DIRECTED_EDGE)
-        extended_graph.add_edge('X3 lag(n=2)', 'X3 lag(n=1)', edge_type=EdgeType.DIRECTED_EDGE)
-        extended_graph.add_edge('X1 lag(n=2)', 'X2 lag(n=1)', edge_type=EdgeType.DIRECTED_EDGE)
         extended_graph.add_edge('X1 lag(n=2)', 'X3 lag(n=2)', edge_type=EdgeType.DIRECTED_EDGE)
+        extended_graph.add_edge('X1 lag(n=3)', 'X1 lag(n=2)', edge_type=EdgeType.DIRECTED_EDGE)
+        extended_graph.add_edge('X2 lag(n=3)', 'X2 lag(n=2)', edge_type=EdgeType.DIRECTED_EDGE)
+        extended_graph.add_edge('X3 lag(n=3)', 'X3 lag(n=2)', edge_type=EdgeType.DIRECTED_EDGE)
+        extended_graph.add_edge('X1 lag(n=3)', 'X2 lag(n=2)', edge_type=EdgeType.DIRECTED_EDGE)
 
         self.assertEqual(extended_dag, extended_graph)
 
@@ -814,11 +825,12 @@ class TestTimeSeriesCausalGraph(unittest.TestCase):
         extended_dag_1 = self.tsdag_1.extend_graph(backward_steps=2)
 
         # create the extended graph from the previous extended graph
-        extended_graph_1.add_edge('X3 lag(n=2)', 'X1 lag(n=1)', edge_type=EdgeType.DIRECTED_EDGE)
-        extended_graph_1.add_edge('X3 lag(n=2)', 'X3 lag(n=1)', edge_type=EdgeType.DIRECTED_EDGE)
         extended_graph_1.add_edge('X3 lag(n=2)', 'X1 lag(n=2)', edge_type=EdgeType.DIRECTED_EDGE)
-        extended_graph_1.add_edge('X1 lag(n=2)', 'X1 lag(n=1)', edge_type=EdgeType.DIRECTED_EDGE)
-        extended_graph_1.add_edge('X2 lag(n=2)', 'X2 lag(n=1)', edge_type=EdgeType.DIRECTED_EDGE)
+        extended_graph_1.add_edge('X1 lag(n=3)', 'X1 lag(n=2)', edge_type=EdgeType.DIRECTED_EDGE)
+        extended_graph_1.add_edge('X2 lag(n=3)', 'X2 lag(n=2)', edge_type=EdgeType.DIRECTED_EDGE)
+        extended_graph_1.add_edge('X3 lag(n=3)', 'X3 lag(n=2)', edge_type=EdgeType.DIRECTED_EDGE)
+        extended_graph_1.add_edge('X3 lag(n=3)', 'X1 lag(n=2)', edge_type=EdgeType.DIRECTED_EDGE)
+        extended_graph_1.add_edge('X3 lag(n=4)', 'X2 lag(n=2)', edge_type=EdgeType.DIRECTED_EDGE)
 
         self.assertEqual(extended_dag_1, extended_graph_1)
 
@@ -827,7 +839,7 @@ class TestTimeSeriesCausalGraph(unittest.TestCase):
 
         gr_ext_dag_2 = self.tsdag_2.copy()
         # add floating node
-        gr_ext_dag_2.add_node('X1 lag(n=1)')
+        gr_ext_dag_2.add_edge('X1 lag(n=3)', 'X1 lag(n=1)')
 
         self.assertEqual(extended_dag_2, gr_ext_dag_2)
 
@@ -1156,10 +1168,16 @@ class TestTimeSeriesCausalGraph(unittest.TestCase):
         extended_graph = ts_cg.extend_graph(backward_steps=1, forward_steps=1)
 
         top_order = extended_graph.get_topological_order()
-        self.assertListEqual(top_order, ['x lag(n=1)', 'y lag(n=1)', 'x', 'y', 'x future(n=1)', 'y future(n=1)'])
+        self.assertListEqual(
+            top_order,
+            ['x lag(n=1)', 'y lag(n=1)', 'x', 'y', 'x future(n=1)', 'y future(n=1)'],
+        )
 
         top_order = extended_graph.get_topological_order(return_all=True)
-        self.assertListEqual(top_order, [['x lag(n=1)', 'y lag(n=1)', 'x', 'y', 'x future(n=1)', 'y future(n=1)']])
+        self.assertListEqual(
+            top_order,
+            [['x lag(n=1)', 'y lag(n=1)', 'x', 'y', 'x future(n=1)', 'y future(n=1)']],
+        )
 
         # Test with floating nodes.
         cg = CausalGraph()
@@ -1199,11 +1217,11 @@ class TestTimeSeriesCausalGraph(unittest.TestCase):
         tsdag = tsdag.extend_graph(backward_steps=2)
 
         order = tsdag.get_topological_order()
-        self.assertListEqual(order, ['x lag(n=2)', 'y lag(n=2)', 'x lag(n=1)', 'y lag(n=1)', 'x', 'y'])
+        self.assertListEqual(order, ['y lag(n=3)', 'x lag(n=2)', 'y lag(n=2)', 'x lag(n=1)', 'y lag(n=1)', 'x', 'y'])
 
         # with return all and respect time ordering to false
         order = tsdag.get_topological_order(return_all=True, respect_time_ordering=False)
-        self.assertIn(['x lag(n=2)', 'x lag(n=1)', 'y lag(n=2)', 'y lag(n=1)', 'x', 'y'], order)
+        self.assertIn(['y lag(n=3)', 'x lag(n=2)', 'x lag(n=1)', 'y lag(n=2)', 'y lag(n=1)', 'x', 'y'], order)
 
         tsdag = TimeSeriesCausalGraph()
         tsdag.add_edge('z', 'y')
@@ -1214,11 +1232,35 @@ class TestTimeSeriesCausalGraph(unittest.TestCase):
         order = tsdag.get_topological_order()
 
         self.assertListEqual(
-            order, ['x lag(n=2)', 'z lag(n=2)', 'y lag(n=2)', 'x lag(n=1)', 'z lag(n=1)', 'y lag(n=1)', 'x', 'z', 'y']
+            order,
+            [
+                'y lag(n=3)',
+                'x lag(n=2)',
+                'z lag(n=2)',
+                'y lag(n=2)',
+                'x lag(n=1)',
+                'z lag(n=1)',
+                'y lag(n=1)',
+                'x',
+                'z',
+                'y',
+            ],
         )
         order = tsdag.get_topological_order(return_all=True, respect_time_ordering=False)
         self.assertIn(
-            ['z lag(n=2)', 'x lag(n=2)', 'y lag(n=2)', 'z lag(n=1)', 'x lag(n=1)', 'y lag(n=1)', 'z', 'x', 'y'], order
+            [
+                'y lag(n=3)',
+                'z lag(n=2)',
+                'x lag(n=2)',
+                'y lag(n=2)',
+                'z lag(n=1)',
+                'x lag(n=1)',
+                'y lag(n=1)',
+                'z',
+                'x',
+                'y',
+            ],
+            order,
         )
 
         tscg = TimeSeriesCausalGraph()


### PR DESCRIPTION
## Description and Motivation
<!--- Describe your changes, and the motivation behind them, in detail -->
- Changed the behavior of `cai_causal_graph.time_series_causal_graph.TimeSeriesCausalGraph.extend_graph` when
  specifying a `backward_steps`. Now, nodes and edges will be added as far back that all nodes at `backward_steps` in
  the past can be inferred. That is, all nodes up to `backward_steps` will now have all their inbound edges and their
  parent nodes added. This means that the extended graph may now have nodes at lags further back than `backward_steps`.

## Additional Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Jira). -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (moving code around, general refactoring improvements)
- [ ] Documentation (documentation)


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I have reviewed my own PR? (review the PR as you are reviewing someone else's PR)
- [X] I have implemented all requirements? (see JIRA, project documentation)
- [ ] I am affecting someone else's work? If so: I have added those people as reviewers?
- [ ] I have added comments to all the bits that are hard to follow
- [X] At a bare minimum, I tested this manually
- [X] I have added unit test(s)
- [ ] Is this a bugfix? If so have I added a regression test?
- [X] Does this PR satisfy the [one PR, one concern](https://medium.com/@fagnerbrack/one-pull-request-one-concern-e84a27dfe9f1) rule?
- [ ] If needed, documentation has been added/updated?
- [X] I have updated the appropriate changelog with a line for my changes
- [ ] If this PR breaks reproducibility, have I added a note in the changelog explaining the break in reproducibility
      and its extent?

## Screenshots (if appropriate):
