### PR TITLE
Improvement: added `CausalGraph.has_non_serializable_metadata`

### DIFF
--- a/cai_causal_graph/causal_graph.py
+++ b/cai_causal_graph/causal_graph.py
@@ -620,6 +620,15 @@ class CausalGraph(HasIdentifier, HasMetadata, CanDictSerialize, CanDictDeseriali
         """Return True if there are no nodes and edges. False otherwise."""
         return len(self.nodes) == 0 and len(self.edges) == 0
 
+    @property
+    def has_non_serializable_metadata(self) -> bool:
+        """
+        Return `True` whether the graph or any node or edge contains non-JSON serializable metadata.
+
+        By default, this returns `False`.
+        """
+        return False
+
     def _check_node_exists(self, identifier: NodeLike) -> str:
         """Validate and return the node identifier."""
         identifier = self._NodeCls.identifier_from(identifier)

--- a/cai_causal_graph/causal_graph.py
+++ b/cai_causal_graph/causal_graph.py
@@ -625,7 +625,8 @@ class CausalGraph(HasIdentifier, HasMetadata, CanDictSerialize, CanDictDeseriali
         """
         Return `True` whether the graph or any node or edge contains non-JSON serializable metadata.
 
-        By default, this returns `False`.
+        By default, this returns `False`. Please note that by default `CausalGraph` does not perform any checks
+        on the metadata. Instead, this method enables any derived classes to implement custom checks.
         """
         return False
 

--- a/changelog.md
+++ b/changelog.md
@@ -27,7 +27,6 @@
 - Added `cai_causal_graph.causal_graph.CausalGraph.has_non_serializable_metadata` method, which returns `False` by default.
 - Dropped support for `python` `3.8` as it is approaching end of life.
 
-
 ## 0.4.10
 
 - Improved documentation by cleaning up a few syntax issues to support the new docs building process.

--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@
 - Generalized `cai_causal_graph.causal_graph.CausalGraph.__eq__` to check for the class of the instance itself, enabling
   to reuse this method by extending classes.
 - Dropped support for `python` `3.8` as it is approaching end of life.
+- Added `cai_causal_graph.causal_graph.CausalGraph.has_non_serializable_metadata` method, which returns `False` by default.
 
 ## 0.4.10
 

--- a/changelog.md
+++ b/changelog.md
@@ -24,8 +24,9 @@
   is specified, it is used to overwrite corresponding information in the constructed node.
 - Generalized `cai_causal_graph.causal_graph.CausalGraph.__eq__` to check for the class of the instance itself, enabling
   to reuse this method by extending classes.
-- Dropped support for `python` `3.8` as it is approaching end of life.
 - Added `cai_causal_graph.causal_graph.CausalGraph.has_non_serializable_metadata` method, which returns `False` by default.
+- Dropped support for `python` `3.8` as it is approaching end of life.
+
 
 ## 0.4.10
 

--- a/tests/test_causal_graph.py
+++ b/tests/test_causal_graph.py
@@ -927,6 +927,11 @@ class TestCausalGraph(unittest.TestCase):
         self.assertEqual(cg.meta['foo'], 'bar')
         self.assertEqual(cg.meta['bar'], 'foo')
 
+    def test_has_non_serial_metadata(self):
+        cg = CausalGraph()
+
+        self.assertFalse(cg.has_non_serializable_metadata)
+
     def test_copy_with_metadata(self):
         o = object()
 


### PR DESCRIPTION
## Description and Motivation
<!--- Describe your changes, and the motivation behind them, in detail -->
- Added `cai_causal_graph.causal_graph.CausalGraph.has_non_serializable_metadata` method, which returns `False` by default.
## Additional Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Jira). -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (moving code around, general refactoring improvements)
- [ ] Documentation (documentation)


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have reviewed my own PR? (review the PR as you are reviewing someone else's PR)
- [ ] I have implemented all requirements? (see JIRA, project documentation)
- [ ] I am affecting someone else's work? If so: I have added those people as reviewers?
- [ ] I have added comments to all the bits that are hard to follow
- [ ] At a bare minimum, I tested this manually
- [ ] I have added unit test(s)
- [ ] Is this a bugfix? If so have I added a regression test?
- [ ] Does this PR satisfy the [one PR, one concern](https://medium.com/@fagnerbrack/one-pull-request-one-concern-e84a27dfe9f1) rule?
- [ ] If needed, documentation has been added/updated?
- [ ] I have updated the appropriate changelog with a line for my changes
- [ ] If this PR breaks reproducibility, have I added a note in the changelog explaining the break in reproducibility
      and its extent?

## Screenshots (if appropriate):
