### PR TITLE
Deprecation: Deprecate kwargs in CausalGraph construction

### DIFF
--- a/cai_causal_graph/causal_graph.py
+++ b/cai_causal_graph/causal_graph.py
@@ -434,23 +434,7 @@ class CausalGraph(HasIdentifier, HasMetadata, CanDictSerialize, CanDictDeseriali
             >>> # add an undirected edge between 'input1' and 'input2'
             >>> causal_graph.add_edge('input1', 'input2', edge_type=EdgeType.UNDIRECTED_EDGE)
 
-            Setting `fully_connected=True` (default) and providing an `input_list` and `n `output_list` during
-            construction, automatically creates a fully-connected bipartite directed causal graph. This means that all
-            inputs are automatically connected to all outputs by means of directed edges. But there will be no edges
-            between inputs and no edges between outputs; this will be a simple two layer graph. For example,
-
-            >>> from cai_causal_graph import CausalGraph
-            >>>
-            >>> input_list = ['input1', 'input2']
-            >>> output_list = ['output1', 'output2']
-            >>>
-            >>> # Create a fully connected graph from inputs to outputs
-            >>> causal_graph = CausalGraph(
-            >>>     input_list=input_list,
-            >>>     output_list=output_list,
-            >>> )
-
-            Finally, it is straightforward to export an instantiated `cai_causal_graph.causal_graph.CausalGraph` to a
+            It is straightforward to export an instantiated `cai_causal_graph.causal_graph.CausalGraph` to a
             serializable dictionary,
 
             >>> causal_graph_dict = causal_graph.to_dict()
@@ -476,14 +460,16 @@ class CausalGraph(HasIdentifier, HasMetadata, CanDictSerialize, CanDictDeseriali
         if input_list is not None:
             warnings.warn(
                 'Passing input_list during construction of a CausalGraph is now deprecated, and will be '
-                'removed in future versions. Please add nodes and edges after construction instead.',
+                'removed in future versions. To maintain this behavior, call add_fully_connected_nodes after '
+                'construction.',
                 category=DeprecationWarning,
             )
             self.add_nodes_from(input_list)
         if output_list is not None:
             warnings.warn(
                 'Passing output_list during construction of a CausalGraph is now deprecated, and will be '
-                'removed in future versions. Please add nodes and edges after construction instead.',
+                'removed in future versions. To maintain this behavior, call add_fully_connected_nodes after '
+                'construction.',
                 category=DeprecationWarning,
             )
             self.add_nodes_from(output_list)
@@ -492,7 +478,8 @@ class CausalGraph(HasIdentifier, HasMetadata, CanDictSerialize, CanDictDeseriali
         if fully_connected and input_list is not None and output_list is not None:
             warnings.warn(
                 'Passing fully_connected during construction of a CausalGraph is now deprecated, and will be '
-                'removed in future versions. Please add nodes and edges after construction instead.',
+                'removed in future versions. To maintain this behavior, call add_fully_connected_nodes after '
+                'construction.',
                 category=DeprecationWarning,
             )
             self.add_fully_connected_nodes(input_list, output_list)

--- a/cai_causal_graph/causal_graph.py
+++ b/cai_causal_graph/causal_graph.py
@@ -16,6 +16,7 @@ limitations under the License.
 from __future__ import annotations
 
 import itertools
+import warnings
 from collections import defaultdict
 from copy import deepcopy
 from functools import wraps
@@ -473,12 +474,27 @@ class CausalGraph(HasIdentifier, HasMetadata, CanDictSerialize, CanDictDeseriali
 
         # Add nodes.
         if input_list is not None:
+            warnings.warn(
+                'Passing input_list during construction of a CausalGraph is now deprecated, and will be '
+                'removed in future versions. Please add nodes and edges after construction instead.',
+                category=DeprecationWarning,
+            )
             self.add_nodes_from(input_list)
         if output_list is not None:
+            warnings.warn(
+                'Passing output_list during construction of a CausalGraph is now deprecated, and will be '
+                'removed in future versions. Please add nodes and edges after construction instead.',
+                category=DeprecationWarning,
+            )
             self.add_nodes_from(output_list)
 
         # create a fully-connected causal graph if specified, using only directed edges
         if fully_connected and input_list is not None and output_list is not None:
+            warnings.warn(
+                'Passing fully_connected during construction of a CausalGraph is now deprecated, and will be '
+                'removed in future versions. Please add nodes and edges after construction instead.',
+                category=DeprecationWarning,
+            )
             self.add_fully_connected_nodes(input_list, output_list)
         # No else needed as no edges need to be added.
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,9 @@
 ## NEXT
 
 - `cai_causal_graph.utils.get_variable_name_and_lag` now allows new lines in the names of variables.
+- Passing `input_list`, `output_list`, and `fully_connected` as arguments to the constructor of a
+  `cai_causal_graph.causal_graph.CausalGraph` is now deprecated, and will be removed in future versions. Please add
+  nodes and edges after construction instead.
 - Upgraded `poetry` version from `1.8.2` to `1.8.3` in the GitHub workflows.
 
 ## 0.5.2

--- a/changelog.md
+++ b/changelog.md
@@ -4,8 +4,8 @@
 
 - `cai_causal_graph.utils.get_variable_name_and_lag` now allows new lines in the names of variables.
 - Passing `input_list`, `output_list`, and `fully_connected` as arguments to the constructor of a
-  `cai_causal_graph.causal_graph.CausalGraph` is now deprecated, and will be removed in future versions. Please add
-  nodes and edges after construction instead.
+  `cai_causal_graph.causal_graph.CausalGraph` is now deprecated, and will be removed in future versions. To maintain
+  this behavior, call `cai_causal_graph.causal_graph.CausalGraph.add_fully_connected_nodes` after construction.
 - Upgraded `poetry` version from `1.8.2` to `1.8.3` in the GitHub workflows.
 
 ## 0.5.2


### PR DESCRIPTION
## Description and Motivation
<!--- Describe your changes, and the motivation behind them, in detail -->
- Passing `input_list`, `output_list`, and `fully_connected` as arguments to the constructor of a
  `cai_causal_graph.causal_graph.CausalGraph` is now deprecated, and will be removed in future versions. Please add
  nodes and edges after construction instead.

## Additional Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here (e.g. Jira). -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor (moving code around, general refactoring improvements)
- [ ] Documentation (documentation)


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have reviewed my own PR? (review the PR as you are reviewing someone else's PR)
- [x] I have implemented all requirements? (see JIRA, project documentation)
- [ ] I am affecting someone else's work? If so: I have added those people as reviewers?
- [ ] I have added comments to all the bits that are hard to follow
- [x] At a bare minimum, I tested this manually
- [ ] I have added unit test(s)
- [ ] Is this a bugfix? If so have I added a regression test?
- [ ] Does this PR satisfy the [one PR, one concern](https://medium.com/@fagnerbrack/one-pull-request-one-concern-e84a27dfe9f1) rule?
- [ ] If needed, documentation has been added/updated?
- [x] I have updated the appropriate changelog with a line for my changes
- [ ] If this PR breaks reproducibility, have I added a note in the changelog explaining the break in reproducibility
      and its extent?

## Screenshots (if appropriate):
