### PR TITLE
Bug: Possible to add Edges forward and backwards

### DIFF
--- a/cai_causal_graph/causal_graph.py
+++ b/cai_causal_graph/causal_graph.py
@@ -742,7 +742,7 @@ class CausalGraph(HasIdentifier, HasMetadata, CanDictSerialize, CanDictDeseriali
         )
 
         if source in self._edges_by_source[destination].keys():
-            raise CausalGraphErrors.EdgeExistsError()
+            raise CausalGraphErrors.ReverseEdgeExistsError()
 
         self._edges_by_source[source][destination] = edge
         self._edges_by_destination[destination][source] = edge

--- a/cai_causal_graph/causal_graph.py
+++ b/cai_causal_graph/causal_graph.py
@@ -741,7 +741,8 @@ class CausalGraph(HasIdentifier, HasMetadata, CanDictSerialize, CanDictDeseriali
             edge.destination
         )
 
-        if source in self._edges_by_source[destination].keys():
+        # raise an error if reverse edge from destination to source has already been defined
+        if self._edges_by_source[destination].get(source) is not None:
             raise CausalGraphErrors.ReverseEdgeExistsError()
 
         self._edges_by_source[source][destination] = edge

--- a/cai_causal_graph/causal_graph.py
+++ b/cai_causal_graph/causal_graph.py
@@ -741,6 +741,9 @@ class CausalGraph(HasIdentifier, HasMetadata, CanDictSerialize, CanDictDeseriali
             edge.destination
         )
 
+        if source in self._edges_by_source[destination].keys():
+            raise CausalGraphErrors.EdgeExistsError()
+
         self._edges_by_source[source][destination] = edge
         self._edges_by_destination[destination][source] = edge
 

--- a/cai_causal_graph/exceptions.py
+++ b/cai_causal_graph/exceptions.py
@@ -46,7 +46,7 @@ class CausalGraphErrors:
         """Error raised when edge already exists in the graph."""
 
     class ReverseEdgeExistsError(Exception):
-        """Error raised when adding any edge from src to dest where dest to src already exists in the graph."""
+        """Error raised when the reverse edge already exists in the graph."""
 
     class EdgeDoesNotExistError(Exception):
         """Error raised when edge does not exist in the graph."""

--- a/cai_causal_graph/exceptions.py
+++ b/cai_causal_graph/exceptions.py
@@ -45,6 +45,9 @@ class CausalGraphErrors:
     class EdgeExistsError(Exception):
         """Error raised when edge already exists in the graph."""
 
+    class ReverseEdgeExistsError(Exception):
+        """Error raised when adding any edge from src to dest where dest to src already exists in the graph."""
+
     class EdgeDoesNotExistError(Exception):
         """Error raised when edge does not exist in the graph."""
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## NEXT
+
+- Fixed a bug that would allow the addition of b--a and b->a edges to a graph with an existing undirected a--b edge in
+  the `cai_causal_graph.causal_graph.CausalGraph._set_edge` method. 
+  - Added the `CausalGraphsError.ReverseEdgeExistsError` exception, which distinguishes errors arising from the
+    introduction of cycles or reverse edges.
+  - `TestCausalGraphPrinting.test_add_edges_from_single_path` and 
+    `TestCausalGraphPrinting.test_add_edges_from_single_path` now assert that a 
+    `CausalGraphsError.ReverseEdgeExistsError` instead of a `CausalGraphsError.ReverseEdgeExistsError` is raised.
+
+
 ## 0.5.4
 
 - Improved the speed of the `cai_causal_graph.causal_graph.CausalGraph.get_descendant_graph` and

--- a/changelog.md
+++ b/changelog.md
@@ -4,11 +4,8 @@
 
 - Fixed a bug that would allow the addition of b--a and b->a edges to a graph with an existing undirected a--b edge in
   the `cai_causal_graph.causal_graph.CausalGraph._set_edge` method.
-  - Added the `CausalGraphsError.ReverseEdgeExistsError` exception, which distinguishes errors arising from the
+  - Added the `CausalGraphError.ReverseEdgeExistsError` exception, which distinguishes errors arising from the
     introduction of cycles or reverse edges.
-  - `TestCausalGraphPrinting.test_add_edges_from_single_path` and
-    `TestCausalGraphPrinting.test_add_edges_from_single_path` now assert that a
-    `CausalGraphsError.ReverseEdgeExistsError` instead of a `CausalGraphsError.ReverseEdgeExistsError` is raised.
 
 ## 0.5.4
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,13 +3,12 @@
 ## NEXT
 
 - Fixed a bug that would allow the addition of b--a and b->a edges to a graph with an existing undirected a--b edge in
-  the `cai_causal_graph.causal_graph.CausalGraph._set_edge` method. 
+  the `cai_causal_graph.causal_graph.CausalGraph._set_edge` method.
   - Added the `CausalGraphsError.ReverseEdgeExistsError` exception, which distinguishes errors arising from the
     introduction of cycles or reverse edges.
-  - `TestCausalGraphPrinting.test_add_edges_from_single_path` and 
-    `TestCausalGraphPrinting.test_add_edges_from_single_path` now assert that a 
+  - `TestCausalGraphPrinting.test_add_edges_from_single_path` and
+    `TestCausalGraphPrinting.test_add_edges_from_single_path` now assert that a
     `CausalGraphsError.ReverseEdgeExistsError` instead of a `CausalGraphsError.ReverseEdgeExistsError` is raised.
-
 
 ## 0.5.4
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,8 @@
 
 ## NEXT
 
-- Fixed a bug that would allow the addition of b--a and b->a edges to a graph with an existing undirected a--b edge in
-  the `cai_causal_graph.causal_graph.CausalGraph._set_edge` method.
+- Fixed a bug in the `cai_causal_graph.causal_graph.CausalGraph.add_edge` method that would allow the addition of an
+  edge between `b` and `a` when the reversed edge, i.e. between `a` and `b` was already specified.
   - Added the `CausalGraphError.ReverseEdgeExistsError` exception, which distinguishes errors arising from the
     introduction of cycles or reverse edges.
 

--- a/tests/test_causal_graph.py
+++ b/tests/test_causal_graph.py
@@ -17,7 +17,6 @@ import copy
 import json
 import unittest
 from copy import deepcopy
-from multiprocessing.managers import Value
 
 import networkx
 import numpy

--- a/tests/test_causal_graph.py
+++ b/tests/test_causal_graph.py
@@ -1414,6 +1414,7 @@ class TestCausalGraphPrinting(unittest.TestCase):
         self.assertEqual(repr(tscg['b']), 'TimeSeriesNode("b", type="continuous")')
 
     def test_add_to_undirected_edges(self):
+        # adding an edge dest-src to an existing edge src-dest should raise an error
 
         cg = CausalGraph()
         cg.add_edge('a', 'b', edge_type=EdgeType.UNDIRECTED_EDGE)
@@ -1422,3 +1423,11 @@ class TestCausalGraphPrinting(unittest.TestCase):
             cg.add_edge('b', 'a')
         with self.assertRaises(CausalGraphErrors.ReverseEdgeExistsError):
             cg.add_edge('b', 'a', edge_type=EdgeType.UNDIRECTED_EDGE)
+        with self.assertRaises(CausalGraphErrors.ReverseEdgeExistsError):
+            cg.add_edge('b', 'a', edge_type=EdgeType.BIDIRECTED_EDGE)
+        with self.assertRaises(CausalGraphErrors.ReverseEdgeExistsError):
+            cg.add_edge('b', 'a', edge_type=EdgeType.UNKNOWN_EDGE)
+        with self.assertRaises(CausalGraphErrors.ReverseEdgeExistsError):
+            cg.add_edge('b', 'a', edge_type=EdgeType.UNKNOWN_DIRECTED_EDGE)
+        with self.assertRaises(CausalGraphErrors.ReverseEdgeExistsError):
+            cg.add_edge('b', 'a', edge_type=EdgeType.UNKNOWN_UNDIRECTED_EDGE)

--- a/tests/test_causal_graph.py
+++ b/tests/test_causal_graph.py
@@ -1422,4 +1422,3 @@ class TestCausalGraphPrinting(unittest.TestCase):
             cg.add_edge('b', 'a')
         with self.assertRaises(CausalGraphErrors.ReverseEdgeExistsError):
             cg.add_edge('b', 'a', edge_type=EdgeType.UNDIRECTED_EDGE)
-

--- a/tests/test_causal_graph.py
+++ b/tests/test_causal_graph.py
@@ -17,6 +17,7 @@ import copy
 import json
 import unittest
 from copy import deepcopy
+from multiprocessing.managers import Value
 
 import networkx
 import numpy
@@ -1412,3 +1413,23 @@ class TestCausalGraphPrinting(unittest.TestCase):
         self.assertEqual(tscg['b'], tscg.get_node('b'))
         self.assertEqual(repr(tscg['a']), 'TimeSeriesNode("a")')
         self.assertEqual(repr(tscg['b']), 'TimeSeriesNode("b", type="continuous")')
+
+    def test_add_to_undirected_edges(self):
+
+        cg = CausalGraph()
+        cg.add_edge('a', 'b', edge_type=EdgeType.UNDIRECTED_EDGE)
+
+        # ExistsError, or Duplicate Error, or other Error?
+        with self.assertRaises(CausalGraphErrors.EdgeExistsError):
+            cg.add_edge('b', 'a')
+        with self.assertRaises(CausalGraphErrors.EdgeExistsError):
+            cg.add_edge('b', 'a', edge_type=EdgeType.UNDIRECTED_EDGE)
+
+        # with self.assertRaises(CausalGraphErrors.EdgeDuplicatedError):
+        #     cg.add_edge('a', 'b')
+        # with self.assertRaises(CausalGraphErrors.EdgeDuplicatedError):
+        #     cg.add_edge('a', 'b', edge_type=EdgeType.UNDIRECTED_EDGE)
+
+
+        # self.assertEqual(0, 1)
+

--- a/tests/test_causal_graph.py
+++ b/tests/test_causal_graph.py
@@ -632,7 +632,7 @@ class TestCausalGraph(unittest.TestCase):
 
         # check conflicting paths raises
         causal_graph.add_edges_from_paths(['a3', 'b', 'c'])
-        with self.assertRaises(CausalGraphErrors.CyclicConnectionError):
+        with self.assertRaises(CausalGraphErrors.ReverseEdgeExistsError):
             causal_graph.add_edges_from_paths(['c', 'b', 'z'])
 
     def test_add_edges_from_multiple_paths(self):
@@ -646,7 +646,7 @@ class TestCausalGraph(unittest.TestCase):
         )
 
         # check conflicting paths raises
-        with self.assertRaises(CausalGraphErrors.CyclicConnectionError):
+        with self.assertRaises(CausalGraphErrors.ReverseEdgeExistsError):
             causal_graph.add_edges_from_paths([['a3', 'b', 'c'], ['c', 'b', 'z']])
 
         # check that invalid paths raises (mix of paths and strings)
@@ -1419,17 +1419,8 @@ class TestCausalGraphPrinting(unittest.TestCase):
         cg = CausalGraph()
         cg.add_edge('a', 'b', edge_type=EdgeType.UNDIRECTED_EDGE)
 
-        # ExistsError, or Duplicate Error, or other Error?
-        with self.assertRaises(CausalGraphErrors.EdgeExistsError):
+        with self.assertRaises(CausalGraphErrors.ReverseEdgeExistsError):
             cg.add_edge('b', 'a')
-        with self.assertRaises(CausalGraphErrors.EdgeExistsError):
+        with self.assertRaises(CausalGraphErrors.ReverseEdgeExistsError):
             cg.add_edge('b', 'a', edge_type=EdgeType.UNDIRECTED_EDGE)
-
-        # with self.assertRaises(CausalGraphErrors.EdgeDuplicatedError):
-        #     cg.add_edge('a', 'b')
-        # with self.assertRaises(CausalGraphErrors.EdgeDuplicatedError):
-        #     cg.add_edge('a', 'b', edge_type=EdgeType.UNDIRECTED_EDGE)
-
-
-        # self.assertEqual(0, 1)
 


### PR DESCRIPTION
## Description and Motivation
Added CausalGraphErrors.ReverseEdgeExistsError Exception, which allows to distinguish acyclicity and double-reverse edges. Introduced a check in the CausalGraph._set_edge() method.

## Additional Context
ADS discovered a bug that allowed the addition of directed and undirected edges between b and a to a graph with an existing undirected edge between a and b. 
Jira link: CAUSALAI-5495

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (moving code around, general refactoring improvements)
- [ ] Documentation (documentation)


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have reviewed my own PR? (review the PR as you are reviewing someone else's PR)
- [ ] I have implemented all requirements? (see JIRA, project documentation)
- [ ] I am affecting someone else's work? If so: I have added those people as reviewers?
- [ ] I have added comments to all the bits that are hard to follow
- [ ] At a bare minimum, I tested this manually
- [ ] I have added unit test(s)
- [ ] Is this a bugfix? If so have I added a regression test?
- [ ] Does this PR satisfy the [one PR, one concern](https://medium.com/@fagnerbrack/one-pull-request-one-concern-e84a27dfe9f1) rule?
- [ ] If needed, documentation has been added/updated?
- [ ] I have updated the appropriate changelog with a line for my changes
- [ ] If this PR breaks reproducibility, have I added a note in the changelog explaining the break in reproducibility
      and its extent?

## Screenshots (if appropriate):
