### PR TITLE
Feature: causalai 5760 method to get all nondirected edges

### DIFF
--- a/cai_causal_graph/causal_graph.py
+++ b/cai_causal_graph/causal_graph.py
@@ -1144,7 +1144,12 @@ class CausalGraph(HasIdentifier, HasMetadata, CanDictSerialize, CanDictDeseriali
         return self._get_edges_by_type(EdgeType.UNDIRECTED_EDGE)
 
     def get_nondirected_edges(self) -> List[Edge]:
-        """Returns a list of edges that are not directed, e.g. not `'X' -> 'Y'`, in the causal graph."""
+        """
+        Returns a list of edges that are not directed, e.g. not `'X' -> 'Y'`, in the causal graph.
+
+        Note that this method is different from `get_undirected_edges`, which only includes 'X' -- 'Y'`.
+        This method includes undirected edges, bidirected edges, and all kinds of unknown edges.
+        """
         return self._get_edges_excluding_type(EdgeType.DIRECTED_EDGE)
 
     def get_bidirected_edges(self) -> List[Edge]:

--- a/cai_causal_graph/causal_graph.py
+++ b/cai_causal_graph/causal_graph.py
@@ -1173,6 +1173,7 @@ class CausalGraph(HasIdentifier, HasMetadata, CanDictSerialize, CanDictDeseriali
         Get a list of edges that have the provided type, e.g. `->`.
 
         :param edge_type: The type to query.
+        :return: A list of edges with the specified type.
         """
         return [edge for edge in self.edges if edge.get_edge_type() == edge_type]
 
@@ -1180,7 +1181,8 @@ class CausalGraph(HasIdentifier, HasMetadata, CanDictSerialize, CanDictDeseriali
         """
         Get a list of edges that do not match the provided type, e.g. `->`.
 
-        :param edge_type: The type to query.
+        :param edge_type: The type of edge to exclude.
+        :return: A list of edges that do not match the specified type.
         """
         return [edge for edge in self.edges if edge.get_edge_type() != edge_type]
 

--- a/cai_causal_graph/causal_graph.py
+++ b/cai_causal_graph/causal_graph.py
@@ -1143,6 +1143,10 @@ class CausalGraph(HasIdentifier, HasMetadata, CanDictSerialize, CanDictDeseriali
         """Returns a list of undirected edges, e.g. `'X' -- 'Y'`, in the causal graph."""
         return self._get_edges_by_type(EdgeType.UNDIRECTED_EDGE)
 
+    def get_nondirected_edges(self) -> List[Edge]:
+        """Returns a list of edges that are not directed, e.g. not `'X' -> 'Y'`, in the causal graph."""
+        return self._get_edges_excluding_type(EdgeType.DIRECTED_EDGE)
+
     def get_bidirected_edges(self) -> List[Edge]:
         """Returns a list of bidirectional edges, e.g. `'X' <-> 'Y'`,  in the causal graph."""
         return self._get_edges_by_type(EdgeType.BIDIRECTED_EDGE)
@@ -1166,6 +1170,14 @@ class CausalGraph(HasIdentifier, HasMetadata, CanDictSerialize, CanDictDeseriali
         :param edge_type: The type to query.
         """
         return [edge for edge in self.edges if edge.get_edge_type() == edge_type]
+
+    def _get_edges_excluding_type(self, edge_type: EdgeType) -> List[Edge]:
+        """
+        Get a list of edges that do not match the provided type, e.g. `->`.
+
+        :param edge_type: The type to query.
+        """
+        return [edge for edge in self.edges if edge.get_edge_type() != edge_type]
 
     def edge_exists(self, /, source: NodeLike, destination: NodeLike, *, edge_type: Optional[EdgeType] = None) -> bool:
         """Returns True if the edge exists. If edge_type is None (default), this ignores edge types."""

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## NEXT
 
-- Added the `cai_causal_graph.causal_graph.CausalGraph.get_nondirected_edges` method, which returns all edhes that are
+- Added the `cai_causal_graph.causal_graph.CausalGraph.get_nondirected_edges` method, which returns all edges that are
   not explicitly directed, i.e. not of type `EdgeType.DIRECTED_EDGE`.
 
 ## 0.5.7

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## NEXT
+
+- Added the `cai_causal_graph.causal_graph.CausalGraph.get_nondirected_edges` method, which returns all edhes that are
+  not explicitly directed, i.e. not of type `EdgeType.DIRECTED_EDGE`.
+
 ## 0.5.7
 
 - Added support for `numpy < 3.0.0` for Python versions `>= 3.10`.

--- a/tests/test_causal_graph_edge_types.py
+++ b/tests/test_causal_graph_edge_types.py
@@ -158,6 +158,7 @@ class TestCausalGraphEdgeTypes(unittest.TestCase):
     def test_get_edges_by_type(self):
         # check that we get the correct edge numbers for the DAG
         self.assertEqual(len(self.dag.get_directed_edges()), 7)
+        self.assertEqual(len(self.dag.get_nondirected_edges()), 0)
         self.assertEqual(len(self.dag.get_undirected_edges()), 0)
         self.assertEqual(len(self.dag.get_bidirected_edges()), 0)
         self.assertEqual(len(self.dag.get_unknown_edges()), 0)
@@ -166,6 +167,7 @@ class TestCausalGraphEdgeTypes(unittest.TestCase):
 
         # check that we get the correct edge numbers for the CPDAG
         self.assertEqual(len(self.cpdag.get_directed_edges()), 4)
+        self.assertEqual(len(self.cpdag.get_nondirected_edges()), 3)
         self.assertEqual(len(self.cpdag.get_undirected_edges()), 3)
         self.assertEqual(len(self.cpdag.get_bidirected_edges()), 0)
         self.assertEqual(len(self.cpdag.get_unknown_edges()), 0)
@@ -174,6 +176,7 @@ class TestCausalGraphEdgeTypes(unittest.TestCase):
 
         # check that we get the correct edge numbers for the MAG
         self.assertEqual(len(self.mag.get_directed_edges()), 2)
+        self.assertEqual(len(self.mag.get_nondirected_edges()), 5)
         self.assertEqual(len(self.mag.get_undirected_edges()), 3)
         self.assertEqual(len(self.mag.get_bidirected_edges()), 2)
         self.assertEqual(len(self.mag.get_unknown_edges()), 0)
@@ -182,6 +185,7 @@ class TestCausalGraphEdgeTypes(unittest.TestCase):
 
         # check that we get the correct edge numbers for the PAG
         self.assertEqual(len(self.pag.get_directed_edges()), 1)
+        self.assertEqual(len(self.pag.get_nondirected_edges()), 6)
         self.assertEqual(len(self.pag.get_undirected_edges()), 2)
         self.assertEqual(len(self.pag.get_bidirected_edges()), 2)
         self.assertEqual(len(self.pag.get_unknown_edges()), 0)


### PR DESCRIPTION
## Description and Motivation
Add `get_nondirected_edges` method that returns all edges that are not explicitly directed.

## Additional Context
(https://causalens.atlassian.net/browse/CUSTSUP-638)

## How Has This Been Tested?
Unit tests with the other `get_X_edges`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (moving code around, general refactoring improvements)
- [ ] Documentation (documentation)


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have reviewed my own PR? (review the PR as you are reviewing someone else's PR)
- [ ] I have implemented all requirements? (see JIRA, project documentation)
- [ ] I am affecting someone else's work? If so: I have added those people as reviewers?
- [ ] I have added comments to all the bits that are hard to follow
- [ ] At a bare minimum, I tested this manually
- [ ] I have added unit test(s)
- [ ] Is this a bugfix? If so have I added a regression test?
- [ ] Does this PR satisfy the [one PR, one concern](https://medium.com/@fagnerbrack/one-pull-request-one-concern-e84a27dfe9f1) rule?
- [ ] If needed, documentation has been added/updated?
- [ ] I have updated the appropriate changelog with a line for my changes
- [ ] If this PR breaks reproducibility, have I added a note in the changelog explaining the break in reproducibility
      and its extent?

## Screenshots (if appropriate):
