### PR TITLE
chore: prepare cai-causal-graph for v0.5.15 release

### DIFF
--- a/cai_causal_graph/__init__.py
+++ b/cai_causal_graph/__init__.py
@@ -31,7 +31,7 @@ __all__ = [
     'VARIABLE_NAME',
 ]
 
-__version__ = '0.5.15'
+__version__ = '0.5.14'
 
 from cai_causal_graph.causal_graph import CausalGraph, Skeleton
 from cai_causal_graph.time_series_causal_graph import TimeSeriesCausalGraph

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ cache_dir = '/dev/null'
 
 [tool.poetry]
 name = "cai-causal-graph"
-version = "0.5.15"
+version = "0.5.14"
 description = "A Causal AI package for causal graphs."
 license = "Apache-2.0"
 authors = ["causaLens <opensource@causalens.com>"]


### PR DESCRIPTION
## Summary
- Restore package version metadata to the currently published `0.5.14`.
- Keep the merged NumPy 2 migration changes intact.
- Allow the tag-triggered release workflow to bump and publish `v0.5.15`.

## Validation
- `poetry check --lock`
- `git diff --check`

## Release
- Intended tag after merge: `v0.5.15`.